### PR TITLE
Synching a11y repo with page changes from osf-selenium-tests repo.

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -31,8 +31,8 @@ class DashboardPage(BaseDashboardPage):
     view_meetings_button = Locator(By.XPATH, '//a[text()="View meetings"]')
     view_preprints_button = Locator(By.XPATH, '//a[text()="View preprints"]')
     first_noteworthy_project = Locator(By.CSS_SELECTOR, '[data-test-noteworthy-project]', settings.LONG_TIMEOUT)
-    institutions_carousel_left_arrow = Locator(By.CSS_SELECTOR, '._InstitutionCarousel__control_16pdz4.carousel-control._left_16pdz4')
-    institutions_carousel_right_arrow = Locator(By.CSS_SELECTOR, '._InstitutionCarousel__control_16pdz4.carousel-control._right_16pdz4')
+    institutions_carousel_left_arrow = Locator(By.CSS_SELECTOR, '.carousel-control.left')
+    institutions_carousel_right_arrow = Locator(By.CSS_SELECTOR, '.carousel-control.right')
 
     # Group Locators
     institution_carousel_logos = GroupLocator(By.CSS_SELECTOR, '.carousel-inner img')

--- a/pages/login.py
+++ b/pages/login.py
@@ -12,10 +12,19 @@ class LoginPage(BasePage):
     identity = Locator(By.ID, 'loginForm', settings.LONG_TIMEOUT)
     username_input = Locator(By.ID, 'username')
     password_input = Locator(By.ID, 'password')
+    login_error_message = Locator(By.CLASS_NAME, 'login-error-inline')
     submit_button = Locator(By.NAME, 'submit')
     remember_me_checkbox = Locator(By.ID, 'rememberMe')
     institutional_login_button = Locator(By.ID, 'instnLogin')
     orcid_login_button = Locator(By.ID, 'orcidlogin')
+    osf_home_link = Locator(By.CSS_SELECTOR, '.navbar-link')
+    sign_up_button = Locator(By.ID, 'osfRegister')
+    reset_password_link = Locator(By.LINK_TEXT, 'Reset password')
+    need_help_link = Locator(By.LINK_TEXT, 'Need help signing in?')
+    cos_footer_link = Locator(By.LINK_TEXT, 'Center for Open Science')
+    terms_of_use_footer_link = Locator(By.LINK_TEXT, 'Terms of Use')
+    privacy_policy_footer_link = Locator(By.LINK_TEXT, 'Privacy Policy')
+    status_footer_link = Locator(By.LINK_TEXT, 'Status')
 
     if 'localhost:5000' in settings.OSF_HOME:
         submit_button = Locator(By.ID, 'submit')
@@ -34,11 +43,76 @@ class LoginPage(BasePage):
         self.submit_button.click()
 
 
+class Login2FAPage(BasePage):
+
+    identity = Locator(By.ID, 'totploginForm')
+    username_input = Locator(By.ID, 'username')
+    oneTimePassword_input = Locator(By.ID, 'oneTimePassword')
+    login_error_message = Locator(By.CLASS_NAME, 'login-error-inline')
+    verify_button = Locator(By.NAME, 'submit')
+    cancel_link = Locator(By.LINK_TEXT, 'Cancel')
+    need_help_link = Locator(By.LINK_TEXT, 'Need help signing in?')
+
+
+class LoginToSPage(BasePage):
+
+    identity = Locator(By.ID, 'tosloginForm')
+    terms_of_use_link = Locator(By.LINK_TEXT, 'Terms of Use')
+    privacy_policy_link = Locator(By.LINK_TEXT, 'Privacy Policy')
+    tos_checkbox = Locator(By.ID, 'termsOfServiceChecked')
+    continue_button = Locator(By.ID, 'primarySubmitButton')
+    cancel_link = Locator(By.LINK_TEXT, 'Cancel and go back to OSF')
+
+
 class InstitutionalLoginPage(BasePage):
     url = settings.OSF_HOME + '/login?campaign=institution'
 
     identity = Locator(By.CSS_SELECTOR, '#institutionSelect')
+    institution_dropdown = Locator(By.ID, 'institutionSelect')
+    sign_in_button = Locator(By.ID, 'institutionSubmit')
+    osf_home_link = Locator(By.CSS_SELECTOR, '.navbar-link')
+    sign_up_button = Locator(By.ID, 'osfRegister')
+    cant_find_institution_link = Locator(By.LINK_TEXT, "I can't find my institution")
+    need_help_link = Locator(By.LINK_TEXT, 'Need help signing in?')
+    sign_in_with_osf_link = Locator(By.LINK_TEXT, 'Sign in with your OSF account')
+    cos_footer_link = Locator(By.LINK_TEXT, 'Center for Open Science')
+    terms_of_use_footer_link = Locator(By.LINK_TEXT, 'Terms of Use')
+    privacy_policy_footer_link = Locator(By.LINK_TEXT, 'Privacy Policy')
+    status_footer_link = Locator(By.LINK_TEXT, 'Status')
+
     dropdown_options = GroupLocator(By.CSS_SELECTOR, '#institutionSelect option')
+
+
+class ForgotPasswordPage(BasePage):
+    url = settings.OSF_HOME + '/forgotpassword/'
+
+    identity = Locator(By.ID, 'forgotPasswordForm')
+
+
+class UnsupportedInstitutionLoginPage(BasePage):
+    url = settings.OSF_HOME + '/login?campaign=unsupportedinstitution'
+
+    identity = Locator(By.ID, 'osfUnsupportedInstitutionLogin')
+
+
+class GenericCASPage(BasePage):
+    url = settings.CAS_DOMAIN
+
+    identity = Locator(By.CLASS_NAME, 'login-error-card')
+    navbar_brand = Locator(By.CLASS_NAME, 'cas-brand-text')
+    auto_redirect_message = Locator(By.CSS_SELECTOR, '#content > div > section > section.text-without-mdi.text-center.text-bold.text-large.margin-large-vertical.title')
+    status_message = Locator(By.CSS_SELECTOR, '#content > div > section > section.card-message > h2')
+    error_detail = Locator(By.CSS_SELECTOR, '#content > div > section > section.card-message > pre')
+
+
+class CASAuthorizationPage(BasePage):
+    url = settings.CAS_DOMAIN + '/oauth2/authorize'
+
+    identity = Locator(By.CLASS_NAME, 'login-section')
+    navbar_brand = Locator(By.CLASS_NAME, 'cas-brand-text')
+    status_message = Locator(By.CSS_SELECTOR, '#content > div > section > section.card-message > h2')
+    allow_button = Locator(By.ID, 'allow')
+    deny_button = Locator(By.ID, 'deny')
 
 
 def login(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To keep the selenium-a11y repo in synch with any relevant changes made in the osf-selenium-tests repo.


## Summary of Changes

- changes to pages/dashboard.py from PR #154 - https://github.com/CenterForOpenScience/osf-selenium-tests/pull/154
- changes to pages/login.py from update to CAS login tests documented by issue #156 - https://github.com/CenterForOpenScience/osf-selenium-tests/issues/156


## Reviewer's Actions
N/A - these changes were all previously reviewed before being implemented in osf-selenium-tests


## Testing Changes Moving Forward
keep monitoring any relevant changes (pages, components, etc.) to the osf-selenium-tests repo to keep this repo in synch


## Ticket
N/A
