### PR TITLE
[ENG-2987] - Create Preprints Accessibility Test

### DIFF
--- a/components/accessibility.py
+++ b/components/accessibility.py
@@ -1,0 +1,57 @@
+import settings
+import os
+
+import pandas as pd
+from axe_selenium_python import Axe
+
+class ApplyA11yRules:
+
+    def run_axe(driver, session, page_name, write_files=True, terminal_errors=True):
+        axe = Axe(driver)
+        # Inject axe-core javascript into page.
+        axe.inject()
+        # Run axe accessibility checks.
+        # TODO: Currently applying all axe rules - parammaterize this so that in the future we can run with
+        #       more options. (i.e. only WCAG 2A rules, or excluding Best Practice rules, etc.)
+        results = axe.run()
+        if write_files:
+            write_results_files(axe, results, page_name)
+        if terminal_errors:
+            # Assert no violations are found
+            assert len(results['violations']) == 0, axe.report(results['violations'])
+
+
+# TODO: Figure out final storage place for results files:
+#       Options include:
+#       - uploading to OSF Project
+#       - shared Google Drive folder
+#       - Github repository (either selenium-a11y repo or maybe separate dedicated repo)
+
+def write_results_files(axe, results, page_name):
+    """ Write results to output .json files (3 separate files for passes, violations, and incomplete) and also
+    convert each .json file to a .csv file.  So there should be 6 separate files created for each execution
+    of axe.  We are using the Panda library to convert .json to .csv files.
+    """
+    # Writing all files to a local folder 'a11y_results' to keep them a little more organized
+    work_dir = 'a11y_results'
+    # Have to first check if the folder exists - if not then create it
+    if not os.path.isdir(work_dir):
+        os.mkdir(work_dir)
+    # Files for Passed Rules
+    file_name_passes = os.path.join(work_dir, 'a11y_' + page_name + '_passes_' + settings.DOMAIN + '.json')
+    axe.write_results(results['passes'], file_name_passes)
+    pandaObject = pd.read_json(file_name_passes)
+    file_name_passes_csv = os.path.join(work_dir, 'a11y_' + page_name + '_passes_' + settings.DOMAIN + '.csv')
+    pandaObject.to_csv(file_name_passes_csv)
+    # Files for Failed Rules (aka Violations)
+    file_name_violations = os.path.join(work_dir, 'a11y_' + page_name + '_violations_' + settings.DOMAIN + '.json')
+    axe.write_results(results['violations'], file_name_violations)
+    pandaObject = pd.read_json(file_name_violations)
+    file_name_violations_csv = os.path.join(work_dir, 'a11y_' + page_name + '_violations_' + settings.DOMAIN + '.csv')
+    pandaObject.to_csv(file_name_violations_csv)
+    # Files for Rules that couldn't be fully evaluated by the rules engine (aka Incomplete)
+    file_name_incomplete = os.path.join(work_dir, 'a11y_' + page_name + '_incomplete_' + settings.DOMAIN + '.json')
+    axe.write_results(results['incomplete'], file_name_incomplete)
+    pandaObject = pd.read_json(file_name_incomplete)
+    file_name_incomplete_csv = os.path.join(work_dir, 'a11y_' + page_name + '_incomplete_' + settings.DOMAIN + '.csv')
+    pandaObject.to_csv(file_name_incomplete_csv)

--- a/components/accessibility.py
+++ b/components/accessibility.py
@@ -7,12 +7,22 @@ from axe_selenium_python import Axe
 class ApplyA11yRules:
 
     def run_axe(driver, session, page_name, write_files=True, terminal_errors=True):
+        """ Use the axe testing engine to perform accessibility checks on a web page
+            Parameters:
+            - page_name - string - unique identifier for the web page being tested
+                - used as part of file name when writing results files
+            - write_files - boolean - used to determine whether or not to write results
+                files - default = True
+            - terminal_errors - boolean - used to deteremine whether or not to output
+                errors to terminal window - default = True
+        """
         axe = Axe(driver)
         # Inject axe-core javascript into page.
         axe.inject()
         # Run axe accessibility checks.
-        # TODO: Currently applying all axe rules - parammaterize this so that in the future we can run with
-        #       more options. (i.e. only WCAG 2A rules, or excluding Best Practice rules, etc.)
+        # TODO: Currently applying all axe rules - parammaterize this so that in the
+        #       future we can run with more options. (i.e. only WCAG 2A rules, or
+        #       excluding Best Practice rules, etc.)
         results = axe.run()
         if write_files:
             write_results_files(axe, results, page_name)
@@ -28,11 +38,20 @@ class ApplyA11yRules:
 #       - Github repository (either selenium-a11y repo or maybe separate dedicated repo)
 
 def write_results_files(axe, results, page_name):
-    """ Write results to output .json files (3 separate files for passes, violations, and incomplete) and also
-    convert each .json file to a .csv file.  So there should be 6 separate files created for each execution
-    of axe.  We are using the Panda library to convert .json to .csv files.
+    """ Write results to output .json files (3 separate files for passes, violations,
+    and incomplete) and also convert each .json file to a .csv file.  So there should
+    be 6 separate files created for each execution of axe.  We are using the Panda
+    library to convert .json to .csv files.
+    Parameters:
+    - axe - instance of the axe testing engine object
+    - results - json object - results object returned from axe containing results of
+        accessibility checks. Results are in json format consisting of 4 separate arrays
+        (passes, violations, incomplete, and inapplicable)
+    - page_name - string - unique identifier for the web page being tested - used as
+        part of file name when writing results files
     """
-    # Writing all files to a local folder 'a11y_results' to keep them a little more organized
+    # Writing all files to a local folder 'a11y_results' to keep them a little more
+    # organized
     work_dir = 'a11y_results'
     # Have to first check if the folder exists - if not then create it
     if not os.path.isdir(work_dir):
@@ -49,7 +68,7 @@ def write_results_files(axe, results, page_name):
     pandaObject = pd.read_json(file_name_violations)
     file_name_violations_csv = os.path.join(work_dir, 'a11y_' + page_name + '_violations_' + settings.DOMAIN + '.csv')
     pandaObject.to_csv(file_name_violations_csv)
-    # Files for Rules that couldn't be fully evaluated by the rules engine (aka Incomplete)
+    # Files for Rules that couldn't be evaluated by the rules engine (aka Incomplete)
     file_name_incomplete = os.path.join(work_dir, 'a11y_' + page_name + '_incomplete_' + settings.DOMAIN + '.json')
     axe.write_results(results['incomplete'], file_name_incomplete)
     pandaObject = pd.read_json(file_name_incomplete)

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -114,3 +114,4 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     view_page = Locator(By.ID, 'view-page')
+    authors_load_indicator = Locator(By.CSS_SELECTOR, '.comma-list > .ball-pulse')

--- a/tests/test_a11y_preprints.py
+++ b/tests/test_a11y_preprints.py
@@ -1,0 +1,82 @@
+import pytest
+import settings
+
+from api import osf_api
+
+from components.accessibility import ApplyA11yRules as a11y
+
+from pages.preprints import (
+    PreprintLandingPage,
+    PreprintSubmitPage,
+    PreprintDiscoverPage,
+    PreprintDetailPage
+)
+
+
+class TestPreprintLandingPage:
+
+    def test_accessibility(self, driver, session):
+        landing_page = PreprintLandingPage(driver)
+        landing_page.goto()
+        assert PreprintLandingPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'preprints')
+
+
+class TestPreprintSubmitPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        submit_page = PreprintSubmitPage(driver)
+        submit_page.goto()
+        assert PreprintSubmitPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prepsub')
+
+
+class TestPreprintDiscoverPage:
+
+    def test_accessibility(self, driver, session):
+        discover_page = PreprintDiscoverPage(driver)
+        discover_page.goto()
+        assert PreprintDiscoverPage(driver, verify=True)
+        discover_page.loading_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'prepdisc')
+
+
+# TODO: Need to figure out a way to run this test in testing environments - some way to search on the
+# Discover page and guarantee that the search results will be from current environment
+@pytest.mark.skipif(not settings.PRODUCTION, reason='Cannot test on stagings as they share SHARE')
+class TestPreprintDetailPage:
+
+    def test_accessibility(self, driver, session):
+        discover_page = PreprintDiscoverPage(driver)
+        discover_page.goto()
+        assert PreprintDiscoverPage(driver, verify=True)
+        discover_page.loading_indicator.here_then_gone()
+        # click on first entry in search results to open the Preprint Detail page
+        discover_page.search_results[0].click()
+        detail_page = PreprintDetailPage(driver, verify=True)
+        # wait for authors list to fully load so that it doesn't trigger list violation
+        detail_page.authors_load_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'prepdet')
+
+
+class TestBrandedProviders:
+    """ For all the Branded Providers in each environment we are just going to load the landing page since the
+    provider pages should be structured just like the OSF Preprint pages which we just tested above. The only
+    real problems that we will be looking for is color contrast issues.
+    """
+
+    def providers():
+        """Return all preprint providers.
+        """
+        return osf_api.get_providers_list()
+
+    @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
+    def provider(self, request):
+        return request.param
+
+    def test_accessibility(self, session, driver, provider):
+        landing_page = PreprintLandingPage(driver, provider=provider)
+        landing_page.goto()
+        assert PreprintLandingPage(driver, verify=True)
+        page_name = 'bp_' + provider['id']
+        a11y.run_axe(driver, session, page_name)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages in the OSF Preprints product area.


## Summary of Changes

- components/accessibility.py - new component that performs the execution of accessibility tests.  Component uses the axe-core library to perform the accessibility checks.  This component will be called by the Preprints test and all subsequent a11y tests in this repository.
- pages/preprints.py - addition of "authors_load_indicator" element to the PreprintDetailPage class - used in the preprints test to wait for the authors section at the top of the page to finish loading before performing a11y checks.
- tests/test_a11y_preprints.py - new test that loads each of the pages associated with the OSF Preprints product area and then performs accessibility checks on each page. Preprints pages include: Preprints Landing Page, Preprints Submit Page, Preprints Discover Page, Preprint Detail Page, and landing page of each Branded Preprint Provider.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/preprints`

Run this test using
`tests/test_a11y_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2987: SEL: Accessibility - Create Preprints Test
https://openscience.atlassian.net/browse/ENG-2987
