### PR TITLE
Add automatic linting / reformatting tools.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+flake:
+	flake8
+
+black:
+	black api base components markers.py pages settings.py tests utils.py
+
+isort:
+	isort .
+
+lintall: black isort flake

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ flake:
 	flake8
 
 black:
-	black api base components markers.py pages settings.py tests utils.py
+	black -S api base components markers.py pages settings.py tests utils.py
 
 isort:
 	isort .

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pre-commit==1.18.3
 ipdb==0.12.2
 axe-selenium-python==2.1.6
 pandas==1.2.4
+isort==5.8.0
+black==19.10b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,16 @@
 # E266: too many leading '#' for block comment
 [flake8]
 ignore = E501,E127,E128,E265,E301,E302,E266,E731,N803,N806,E701
-max-line-length = 100
+# max-line-length = 100
 exclude = .git,tasks/*,settings/*,misc/*,helpers/*,staging/*,selenium/*
+max-line-length = 88
+extend-ignore = E203, W503
+inline-quotes = double
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ ignore = E501,E127,E128,E265,E301,E302,E266,E731,N803,N806,E701
 exclude = .git,tasks/*,settings/*,misc/*,helpers/*,staging/*,selenium/*
 max-line-length = 88
 extend-ignore = E203, W503
-inline-quotes = double
+# inline-quotes = double
 
 [isort]
 multi_line_output = 3


### PR DESCRIPTION
## Purpose

Settle on one code-formatting convention, and let tools enforce it for us

Black style opinions: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html


## Summary of Changes

Add `black` & `isort` to deps and settle on a common configuration that they and `flake` can agree on.

Add a `Makefile` with simple targets for each tool, plus a composite target.

## Reviewer's Actions

`git fetch <remote> pull/<PR_number>/head:<branch_name>`

I haven't applied the formatting yet.  This just sets up the tools.  To try it:

```
$ pip install -r devRequirements.txt
$ make lintall
```

The result will be a great-big-diff that reformats all the code.  Subsequent `flake`, `black`, and `isort` runs shouldn't change the code any further until actual code functionality changes are applied.

**Actions**:

1. Review the changes to see if you're happy with them.  I've used the default `black` config and changed `flake` and `isort` to comply.  If there are styles you prefer, we can investigate how to change our config.
2. Any PRs opened before the formatting is applied will conflict massively.  Either reformat the open PRs or merge them first, then apply the reformatting.

## Ticket

*No ticket*