### PR TITLE
[ENG-2994] - Create User Accessibility Test

### DIFF
--- a/pages/user.py
+++ b/pages/user.py
@@ -44,6 +44,9 @@ class ProfileInformationPage(BaseUserSettingsPage):
     middle_name_input = Locator(By.CSS_SELECTOR, '#names > div > form > div:nth-child(5) > input')
     save_button = Locator(By.CSS_SELECTOR, '#names > div > form > div.p-t-lg.p-b-lg > button.btn.btn-success')
     update_success = Locator(By.CSS_SELECTOR, '.text-success')
+    social_tab_link = Locator(By.LINK_TEXT, 'Social')
+    employment_tab_link = Locator(By.LINK_TEXT, 'Employment')
+    education_tab_link = Locator(By.LINK_TEXT, 'Education')
 
 class AccountSettingsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/account/'
@@ -59,6 +62,7 @@ class NotificationsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/notifications/'
 
     identity = Locator(By.CSS_SELECTOR, '#notificationSettings')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
 
 class EmberDeveloperAppsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/applications/'
@@ -72,6 +76,11 @@ class DeveloperAppsPage(BaseUserSettingsPage):
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Developer apps"')
 
+class CreateDeveloperAppPage(BaseUserSettingsPage):
+    url = settings.OSF_HOME + '/settings/applications/create'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-developer-app-name]')
+
 class EmberPersonalAccessTokenPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/tokens/'
 
@@ -83,3 +92,8 @@ class PersonalAccessTokenPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/tokens/'
 
     identity = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Personal access"]')
+
+class CreatePersonalAccessTokenPage(BaseUserSettingsPage):
+    url = settings.OSF_HOME + '/settings/tokens/create'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-token-name]')

--- a/tests/test_a11y_user.py
+++ b/tests/test_a11y_user.py
@@ -1,0 +1,137 @@
+import pytest
+
+from components.accessibility import ApplyA11yRules as a11y
+
+from pages.user import (
+    AccountSettingsPage,
+    ConfigureAddonsPage,
+    CreateDeveloperAppPage,
+    CreatePersonalAccessTokenPage,
+    EmberDeveloperAppsPage,
+    EmberPersonalAccessTokenPage,
+    NotificationsPage,
+    ProfileInformationPage,
+    UserProfilePage
+)
+
+
+class TestUserProfilePage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        profile_page = UserProfilePage(driver)
+        profile_page.goto()
+        assert UserProfilePage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrProf')
+
+
+class TestUserSettingsProfileInformationPage:
+
+    @pytest.fixture()
+    def profile_information_page(self, driver, must_be_logged_in):
+        profile_information_page = ProfileInformationPage(driver)
+        profile_information_page.goto()
+        return profile_information_page
+
+    def test_accessibility_name_tab(self, driver, session, profile_information_page):
+        """ Test Name Tab (default) of User Settings Profile Information Page
+        """
+        assert ProfileInformationPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetPrfName')
+
+    def test_accessibility_social_tab(self, driver, session, profile_information_page):
+        """ Test Social Tab of User Settings Profile Information Page
+        """
+        # Running Axe in the previous step leaves you at the bottom of the page, so we
+        # need to scroll back up to the Social tab link before we can click it and then
+        # run Axe again.
+        profile_information_page.scroll_into_view(profile_information_page.social_tab_link.element)
+        profile_information_page.social_tab_link.click()
+        assert ProfileInformationPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetPrfSoc')
+
+    def test_accessibility_employment_tab(self, driver, session, profile_information_page):
+        """ Test Employment Tab of User Settings Profile Information Page
+        """
+        # Running Axe in the previous step leaves you at the bottom of the page, so we
+        # need to scroll back up to the Employment tab link before we can click it and then
+        # run Axe again.
+        profile_information_page.scroll_into_view(profile_information_page.employment_tab_link.element)
+        profile_information_page.employment_tab_link.click()
+        assert ProfileInformationPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetPrfEmp')
+
+    def test_accessibility_education_tab(self, driver, session, profile_information_page):
+        """ Test Education Tab of User Settings Profile Information Page
+        """
+        # Running Axe in the previous step leaves you at the bottom of the page, so we
+        # need to scroll back up to the Education tab link before we can click it and then
+        # run Axe again.
+        profile_information_page.scroll_into_view(profile_information_page.education_tab_link.element)
+        profile_information_page.education_tab_link.click()
+        assert ProfileInformationPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetPrfEd')
+
+
+class TestUserSettingsAccountSettingsPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        account_settings_page = AccountSettingsPage(driver)
+        account_settings_page.goto()
+        assert AccountSettingsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetAccnt')
+
+
+class TestUserSettingsConfigureAddonsPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        configure_addons_page = ConfigureAddonsPage(driver)
+        configure_addons_page.goto()
+        assert ConfigureAddonsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetAddons')
+
+
+class TestUserSettingsNotificationsPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        notifications_page = NotificationsPage(driver)
+        notifications_page.goto()
+        assert NotificationsPage(driver, verify=True)
+        # wait for Notification Preferences section to finish loading
+        notifications_page.loading_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'usrSetNtfctns')
+
+
+class TestUserSettingsDeveloperAppsPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        developer_apps_page = EmberDeveloperAppsPage(driver)
+        developer_apps_page.goto()
+        assert EmberDeveloperAppsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetDevApp')
+
+
+class TestUserSettingsCreateDeveloperAppPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        create_dev_app_page = CreateDeveloperAppPage(driver)
+        create_dev_app_page.goto()
+        assert CreateDeveloperAppPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetCrtDevApp')
+
+
+class TestUserSettingsPersonalAccessTokensPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        personal_access_tokens_page = EmberPersonalAccessTokenPage(driver)
+        personal_access_tokens_page.goto()
+        assert EmberPersonalAccessTokenPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetPAT')
+
+
+class TestUserSettingsCreatePersonalAccessTokenPage:
+
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        create_personal_access_tokens_page = CreatePersonalAccessTokenPage(driver)
+        create_personal_access_tokens_page.goto()
+        assert CreatePersonalAccessTokenPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'usrSetCrtPAT')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages in the OSF User product area.


## Summary of Changes

- pages/user.py - added new elements to existing user pages (page tabs and loading indicator) and added 2 new page elements: CreateDeveloperAppPage and CreatePersonalAccessTokenPage
- tests/test_a11y_user.py - new test that loads each of the pages associated with the OSF User product area and then performs accessibility checks on each page. User pages include: User Profile Page, User Settings Profile Information Page, User Settings Account Settings Page, User Settings Configure Add-ons Page, User Settings Notifications Page, User Settings Developer Apps Page, User Settings Create Developer App Page, User Settings Personal Access Tokens Page, and User Settings Create Personal Access Token Page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/user`

Run this test using
`tests/test_a11y_user.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2994: SEL: Accessibility - Create User Test
https://openscience.atlassian.net/browse/ENG-2994
