### PR TITLE
[ENG-2991] - Create New Project Accessibility Test

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -15,7 +15,8 @@ from pages.base import GuidBasePage, OSFBasePage
 
 class ProjectPage(GuidBasePage):
 
-    identity = Locator(By.CSS_SELECTOR, '#overview > nav#projectSubnav')
+    # identity = Locator(By.CSS_SELECTOR, '#overview > nav#projectSubnav')
+    identity = Locator(By.CSS_SELECTOR, 'nav#projectSubnav')
     title = Locator(By.ID, 'nodeTitleEditable', settings.LONG_TIMEOUT)
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
     title_edit_submit_button = Locator(By.CSS_SELECTOR, '.editable-submit')
@@ -105,9 +106,55 @@ class FilesPage(GuidBasePage):
         By.CSS_SELECTOR, '#folderRow .fangorn-toolbar-icon'
     )
     delete_modal = Locator(By.CSS_SELECTOR, 'span.btn:nth-child(1)')
+    loading_indicator = Locator(
+        By.CSS_SELECTOR, '#treeGrid > .ball-scale', settings.LONG_TIMEOUT
+    )
 
 
 """Note that the class FilesPage in pages/project.py is used for test_project_files.py.
 The class FileWidget in components/project.py is used for tests test_file_widget_loads
 and test_addon_files_load in test_project.py.
 In the future, we may want to put all files tests in one place."""
+
+
+class FileViewPage(GuidBasePage):
+
+    identity = Locator(By.ID, 'fileTitleEditable', settings.LONG_TIMEOUT)
+    file_nav_loading_indicator = Locator(
+        By.CSS_SELECTOR,
+        '#file-navigation > div > div > #grid > div > .ball-scale',
+        settings.LONG_TIMEOUT,
+    )
+
+
+class WikiPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/wiki/'
+
+    identity = Locator(By.ID, 'wikiName')
+
+
+class RegistrationsPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/registrations/'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-registrations-container]')
+
+
+class ContributorsPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/contributors/'
+
+    identity = Locator(By.ID, 'manageContributors')
+
+
+class AddonsPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/addons/'
+
+    identity = Locator(By.ID, 'selectAddon')
+
+
+class SettingsPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/settings/'
+
+    identity = Locator(By.ID, 'projectSettings')
+    email_notifications_loading_indicator = Locator(
+        By.CSS_SELECTOR, '#grid > div > .ball-scale'
+    )

--- a/pages/project.py
+++ b/pages/project.py
@@ -15,8 +15,7 @@ from pages.base import GuidBasePage, OSFBasePage
 
 class ProjectPage(GuidBasePage):
 
-    # identity = Locator(By.CSS_SELECTOR, '#overview > nav#projectSubnav')
-    identity = Locator(By.CSS_SELECTOR, 'nav#projectSubnav')
+    identity = Locator(By.ID, 'projectScope')
     title = Locator(By.ID, 'nodeTitleEditable', settings.LONG_TIMEOUT)
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
     title_edit_submit_button = Locator(By.CSS_SELECTOR, '.editable-submit')
@@ -137,6 +136,7 @@ class RegistrationsPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/registrations/'
 
     identity = Locator(By.CSS_SELECTOR, '[data-test-registrations-container]')
+    first_registration_title = Locator(By.CSS_SELECTOR, '[data-test-node-title]')
 
 
 class ContributorsPage(GuidBasePage):

--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -103,6 +103,10 @@ class TestAnalyticsPage:
         analytics_page = AnalyticsPage(driver, guid=default_project.id)
         analytics_page.goto()
         assert AnalyticsPage(driver, verify=True)
+        # wait until analytics graphs load
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, '.keen-dataviz-stage'))
+        )
         a11y.run_axe(driver, session, 'prjAnlytcs')
 
 
@@ -115,6 +119,8 @@ class TestRegistrationsPage:
         registrations_page = RegistrationsPage(driver, guid=default_project.id)
         registrations_page.goto()
         assert RegistrationsPage(driver, verify=True)
+        # wait until Registration cards are loaded if there are any
+        registrations_page.first_registration_title.present()
         a11y.run_axe(driver, session, 'prjReg')
 
 

--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -1,0 +1,192 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+import markers
+from api import osf_api
+from components.accessibility import ApplyA11yRules as a11y
+from pages.project import (
+    AddonsPage,
+    AnalyticsPage,
+    ContributorsPage,
+    FilesPage,
+    FileViewPage,
+    ForksPage,
+    ProjectPage,
+    RegistrationsPage,
+    RequestAccessPage,
+    SettingsPage,
+    WikiPage,
+)
+
+
+class TestProjectPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Project Overview page test we are creating a new dummy test project
+        and then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        project_page = ProjectPage(driver, guid=default_project.id)
+        project_page.goto()
+        assert ProjectPage(driver, verify=True)
+        # wait until file widget has fully loaded so that we can ensure that all sections
+        # of project page have fully loaded before applying a11y rules
+        project_page.file_widget.loading_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'project')
+
+
+class TestFilesPage:
+    def test_accessibility(self, driver, session, project_with_file, must_be_logged_in):
+        """ For the Project Files page test we are creating a new dummy test project and
+        then deleting it after we have finished unless we are running in Production, then
+        we are using a Preferred Node from the environment settings file.
+        """
+        files_page = FilesPage(driver, guid=project_with_file.id)
+        files_page.goto()
+        files_page.loading_indicator.here_then_gone()
+        assert FilesPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjFiles')
+
+
+class TestFileViewPage:
+    def test_accessibility(self, driver, session, project_with_file, must_be_logged_in):
+        """ For the File View page test we are creating a new dummy test project and
+        then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        files_page = FilesPage(driver, guid=project_with_file.id)
+        files_page.goto()
+        files_page.loading_indicator.here_then_gone()
+        # Wait until fangorn has loaded at least one of the files in the tree
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '#tb-tbody div[data-level="3"]')
+            )
+        )
+        WebDriverWait(driver, 10).until(
+            EC.invisibility_of_element_located(
+                (By.CSS_SELECTOR, '#tb-tbody .fa-refresh')
+            )
+        )
+        for file in files_page.fangorn_rows:
+            # open the first text file you find
+            if '.txt' in file.text:
+                file.click()
+                break
+        file_view_page = FileViewPage(driver, verify=True)
+        # wait for file navigation menu and iframe to load before running axe
+        file_view_page.file_nav_loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, 'mfrIframe'))
+        )
+        a11y.run_axe(driver, session, 'fileView')
+
+
+class TestWikiPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Wiki page test we are creating a new dummy test project and then
+        deleting it after we have finished unless we are running in Production, then
+        we are using a Preferred Node from the environment settings file.
+        """
+        wiki_page = WikiPage(driver, guid=default_project.id)
+        wiki_page.goto()
+        assert WikiPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjWiki')
+
+
+class TestAnalyticsPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Analytics page test we are creating a new dummy test project and
+        then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        analytics_page = AnalyticsPage(driver, guid=default_project.id)
+        analytics_page.goto()
+        assert AnalyticsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjAnlytcs')
+
+
+class TestRegistrationsPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Registrations page test we are creating a new dummy test project
+        and then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        registrations_page = RegistrationsPage(driver, guid=default_project.id)
+        registrations_page.goto()
+        assert RegistrationsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjReg')
+
+
+class TestContributorsPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Contributors page test we are creating a new dummy test project
+        and then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        contributors_page = ContributorsPage(driver, guid=default_project.id)
+        contributors_page.goto()
+        assert ContributorsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjCntrb')
+
+
+class TestAddonsPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Add-ons page test we are creating a new dummy test project and then
+        deleting it after we have finished unless we are running in Production, then we
+        are using a Preferred Node from the environment settings file.
+        """
+        addons_page = AddonsPage(driver, guid=default_project.id)
+        addons_page.goto()
+        assert AddonsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjAddons')
+
+
+class TestSettingsPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Settings page test we are creating a new dummy test project and
+        then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        settings_page = SettingsPage(driver, guid=default_project.id)
+        settings_page.goto()
+        settings_page.email_notifications_loading_indicator.here_then_gone()
+        assert SettingsPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjSttngs')
+
+
+@markers.dont_run_on_prod
+class TestForksPage:
+    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+        """ For the Forks page test we are creating a new dummy test project and
+        then deleting it after we have finished - also deleting the new fork that
+        is created
+        """
+        forks_page = ForksPage(driver, guid=default_project.id)
+        forks_page.goto()
+        assert ForksPage(driver, verify=True)
+        # create a new fork so that we can make sure that data display is a11y compliant
+        forks_page.new_fork_button.click()
+        forks_page.create_fork_modal_button.click()
+        forks_page.info_toast.present()
+        forks_page.reload()
+        forks_page.verify()
+        forks_page.fork_authors.present()
+        assert len(forks_page.listed_forks) == 1
+        # clean-up leftover fork
+        fork_guid = forks_page.fork_link.get_attribute('data-test-node-title')
+        osf_api.delete_project(session, fork_guid, None)
+        a11y.run_axe(driver, session, 'prjForks')
+
+
+class TestRequestAccessPage:
+    def test_accessibility(
+        self, driver, session, default_project_page, must_be_logged_in_as_user_two
+    ):
+        """ For the Request Access page test we are creating a new dummy test project
+        and then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        default_project_page.goto(expect_redirect_to=RequestAccessPage)
+        assert RequestAccessPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'prjReqAcc')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages associated with an OSF Project.


## Summary of Changes

- pages/project.py - updates to identity locator for existing Project Overview page, as well as addition of loading indicator element on the existing Files page.  Also added the following new page definition classes: FileViewPage, WikiPage, RegistrationsPage, ContributorsPage, AddonsPage, and SettingsPage
- tests/test_a11y_project.py - new test that loads each of the pages associated with an OSF Project and then performs accessibility checks on each page.  Project pages include: Project Overview Page, Project Files Page, Project File View Page, Project Wiki Page, Project Analytics Page, Project Registrations Page, Project Contributors Page, Project Add-ons Page, Project Settings Page, Project Forks Page, and Request Access to Project Page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/project`

Run this test using
`tests/test_a11y_project.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2991: SEL: Accessibility - Create Project Test
https://openscience.atlassian.net/browse/ENG-2991
