### PR TITLE
[ENG-2989] - Create Institutions Accessibility Test

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -84,12 +84,18 @@ def delete_all_quickfiles(session, quickfiles_url):
         delete_file(session, delete_url)
 
 
-def get_all_institutions(session):
+def get_all_institutions(session=None, data_type='names'):
+    if not session:
+        session = get_default_session()
     url = '/v2/institutions/'
     data = session.get(url)
     institutions = []
-    for institution in data['data']:
-        institutions.append(institution['attributes']['name'])
+    if data_type == 'names':
+        for institution in data['data']:
+            institutions.append(institution['attributes']['name'])
+    elif data_type == 'ids':
+        for institution in data['data']:
+            institutions.append(institution['id'])
     return institutions
 
 

--- a/pages/institutions.py
+++ b/pages/institutions.py
@@ -22,9 +22,33 @@ class InstitutionsLandingPage(OSFBasePage):
     navbar = ComponentLocator(InstitutionsNavbar)
 
 
-class InstitutionBrandedPage(OSFBasePage):
+class BaseInstitutionPage(OSFBasePage):
+
+    base_url = settings.OSF_HOME + '/institutions/'
+    url_addition = ''
+
+    def __init__(self, driver, verify=False, institution_id=''):
+        self.institution_id = institution_id
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        return self.base_url + self.institution_id + self.url_addition
+
+
+class InstitutionBrandedPage(BaseInstitutionPage):
 
     identity = Locator(
         By.CSS_SELECTOR,
         '#fileBrowser > div.db-header.row > div.db-buttonRow.col-xs-12.col-sm-4.col-lg-3 > div > input',
     )
+
+    empty_collection_indicator = Locator(By.CLASS_NAME, 'db-non-load-template')
+
+
+class InstitutionAdminDashboardPage(BaseInstitutionPage):
+
+    url_addition = '/dashboard'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Dashboard"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)

--- a/tests/test_a11y_institutions.py
+++ b/tests/test_a11y_institutions.py
@@ -1,0 +1,65 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+import markers
+from api import osf_api
+from components.accessibility import ApplyA11yRules as a11y
+from pages.institutions import (
+    InstitutionAdminDashboardPage,
+    InstitutionBrandedPage,
+    InstitutionsLandingPage,
+)
+
+
+class TestInstitutionsLandingPage:
+    def test_accessibility(self, driver, session):
+        landing_page = InstitutionsLandingPage(driver)
+        landing_page.goto()
+        assert InstitutionsLandingPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'institutions')
+
+
+class TestBrandedInstitutionPages:
+    """ Test the Branded Institution Page for each institution in the environment. Use the osf api to get
+    the list of institution ids and then load each branded iinstitution page and run the axe test engine.
+    """
+
+    def institutions():
+        """ Return all institution ids.
+        """
+        return osf_api.get_all_institutions(data_type='ids')
+
+    @pytest.fixture(params=institutions())
+    def institution(self, request):
+        return request.param
+
+    def test_accessibility(self, driver, session, institution):
+        institution_page = InstitutionBrandedPage(driver, institution_id=institution)
+        institution_page.goto()
+        assert InstitutionBrandedPage(driver, verify=True)
+        # first check if the collection is empty - this may often be the case in the test environments
+        if institution_page.empty_collection_indicator.absent():
+            # wait for projects table to start loading before calling axe
+            WebDriverWait(driver, 60).until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, '#tb-tbody > div > div > div.tb-row')
+                )
+            )
+        page_name = 'bi_' + institution
+        a11y.run_axe(driver, session, page_name)
+
+
+# Can't run this is Production since I don't have admin access to any institutions in Production
+@markers.dont_run_on_prod
+class TestInstitutionAdminDashboardPage:
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        """ Test using the COS admin dahsboard page - user must already be setup as an admin for the
+        COS institution in each environment through the OSF admin app.
+        """
+        dashboard_page = InstitutionAdminDashboardPage(driver, institution_id='cos')
+        dashboard_page.goto()
+        assert InstitutionAdminDashboardPage(driver, verify=True)
+        dashboard_page.loading_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'biadmindash')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages in the OSF Institutions product area.


## Summary of Changes

- api/osf_api.py - modify get_all_institutions function to provide the option of retrieving a list of institutions using institution id instead of just retrieving by institution name.
- pages/institutions.py - add new classes: BaseInstitutionPage and InstitutionAdminDashboardPage and modify class InstitutionBrandedPage
- tests/test_a11y_institutions.py -  new test that loads each of the pages associated with the OSF Institutions product area and then performs accessibility checks on each page. Institutions pages include: Institutions Landing Page, Branded Institution Page (for each institution in the specific environment), and Institutional Admin Dashboard Page.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/Institutions`

Run this test using
`tests/test_a11y_institutions.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2989: SEL: Accessibility - Create Institutions Test
https://openscience.atlassian.net/browse/ENG-2989
