### PR TITLE
[ENG-3207] - Enhance a11y test of Preprint Submit page

### DIFF
--- a/tests/test_a11y_preprints.py
+++ b/tests/test_a11y_preprints.py
@@ -1,5 +1,9 @@
 import pytest
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
+import markers
 import settings
 from api import osf_api
 from components.accessibility import ApplyA11yRules as a11y
@@ -20,15 +24,65 @@ class TestPreprintLandingPage:
 
 
 class TestPreprintSubmitPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    @pytest.mark.skipif(
+        not settings.PRODUCTION, reason='This version is only for Production'
+    )
+    def test_accessibility_prod(self, driver, session, must_be_logged_in):
+        """This is a lite version of the Preprint Submit page test just for Production.
+        It just navigates to the Submit page without attempting to start a new Preprint.
+        """
         submit_page = PreprintSubmitPage(driver)
         submit_page.goto()
         assert PreprintSubmitPage(driver, verify=True)
         a11y.run_axe(driver, session, 'prepsub')
 
+    @markers.dont_run_on_prod
+    def test_accessibility_non_prod(
+        self, driver, session, project_with_file, must_be_logged_in
+    ):
+        """This version of the Preprint Submit page test will run on any of the testing
+        environments since it creates a fake project with file attached from which a new
+        Preprint can be created. We do not want to do this in Production.
+        """
+        submit_page = PreprintSubmitPage(driver)
+        submit_page.goto()
+        assert PreprintSubmitPage(driver, verify=True)
+        # Start the process of creating a new preprint so that we can get to the point
+        #     where we can expand the Basics section before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of(submit_page.select_a_service_help_text)
+        )
+        submit_page.select_a_service_save_button.click()
+        submit_page.upload_from_existing_project_button.click()
+        submit_page.upload_project_selector.click()
+        submit_page.upload_project_help_text.here_then_gone()
+        submit_page.upload_project_selector_project.click()
+        submit_page.upload_select_file.click()
+        submit_page.upload_file_save_continue.click()
+        submit_page.public_available_button.click()
+        submit_page.public_data_input.click()
+        submit_page.public_data_input.send_keys_deliberately('https://osf.io/')
+        submit_page.scroll_into_view(submit_page.preregistration_no_button.element)
+        submit_page.preregistration_no_button.click()
+        submit_page.preregistration_input.click()
+        submit_page.preregistration_input.send_keys_deliberately('QA Testing')
+        submit_page.save_author_assertions.click()
+        submit_page.basics_abstract_input.click()
+        a11y.run_axe(driver, session, 'prepsub')
+
 
 class TestPreprintDiscoverPage:
     def test_accessibility(self, driver, session):
+        # The previous test (Submit page - non prod) may trigger a pop-up alert
+        #     messagebox that leaving the page will cause data to not be saved.  At
+        #     this point this seems to only be happening with Chrome.  If we get
+        #     the alert then we need to accept it before moving on the rest of the
+        #     test.
+        try:
+            WebDriverWait(driver, 3).until(EC.alert_is_present())
+            driver.switch_to.alert.accept()
+        except TimeoutException:
+            pass
         discover_page = PreprintDiscoverPage(driver)
         discover_page.goto()
         assert PreprintDiscoverPage(driver, verify=True)
@@ -36,8 +90,9 @@ class TestPreprintDiscoverPage:
         a11y.run_axe(driver, session, 'prepdisc')
 
 
-# TODO: Need to figure out a way to run this test in testing environments - some way to search on the
-# Discover page and guarantee that the search results will be from current environment
+# TODO: Need to figure out a way to run this test in testing environments - some way
+#     to search on the Discover page and guarantee that the search results will be
+#     from current environment
 @pytest.mark.skipif(
     not settings.PRODUCTION, reason='Cannot test on stagings as they share SHARE'
 )
@@ -56,9 +111,10 @@ class TestPreprintDetailPage:
 
 
 class TestBrandedProviders:
-    """ For all the Branded Providers in each environment we are just going to load the landing page since the
-    provider pages should be structured just like the OSF Preprint pages which we just tested above. The only
-    real problems that we will be looking for is color contrast issues.
+    """For all the Branded Providers in each environment we are just going to load the
+    landing page since the provider pages should be structured just like the OSF Preprint
+    pages which we just tested above. The only real problems that we will be looking for
+    are color contrast issues.
     """
 
     def providers():


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To enhance the accessibility test of the Preprints Submit page by starting an actual preprint and expanding at least one of the form sections so that color contrast checks of the form elements can be more accurate.


## Summary of Changes

- tests/test_a11y_preprints.py - in TestPreprintSubmitPage class, renamed existing method - test_accessibility to test_accessibility_prod and added marker to only run this method in Production.  Added new method - test_accessibility_non_prod to be run in all the testing environments.  This new method contains code to start creating a new preprint and continue until it reaches the Basics section of the form. Once the Basics section is reached and expanded on the page, then axe is called to perform the accessibility checks.  In TestPreprintDiscoverPage class, which immediately follows the TestPreprintSubmitPage class, I added code to check if an alert messagebox exists and if so accept it so that we can move on with the test.  The alert messagebox appears in the Chrome browser when attempting to leave the Preprints Submit page before completing the form.  For some reason the messagebox is ignored by the Firefox driver.  Also standardized some comments.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/preprints`

Run this test using
`tests/test_a11y_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3207: SEL: A11y - Preprints Test - Add Expansion of Basics section to Preprint Submit Page
https://openscience.atlassian.net/browse/ENG-3207
