### PR TITLE
[ENG-2990] - Create Meetings Accessibility Test

### DIFF
--- a/pages/meetings.py
+++ b/pages/meetings.py
@@ -51,7 +51,9 @@ class MeetingDetailPage(BaseMeetingsPage):
     # test url functionality
     url = settings.OSF_HOME + '/view/'
 
-    identity = Locator(By.CSS_SELECTOR, 'button[data-test-meeting-toggle-panel-button]')
+    identity = Locator(
+        By.CSS_SELECTOR, 'div._toggle-button-and-homepage-link-container_1h8tly'
+    )
     meeting_title = Locator(By.CSS_SELECTOR, 'h1[data-test-meeting-name]')
     entry_download_button = Locator(
         By.CSS_SELECTOR,

--- a/tests/test_a11y_meetings.py
+++ b/tests/test_a11y_meetings.py
@@ -1,0 +1,46 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+
+from components.accessibility import ApplyA11yRules as a11y
+from pages.meetings import MeetingDetailPage, MeetingsPage
+
+
+class TestMeetingsLandingPage:
+    def test_accessibility(self, driver, session):
+        meetings_page = MeetingsPage(driver)
+        meetings_page.goto()
+        assert MeetingsPage(driver, verify=True)
+        # Click the Register and Upload butttons to reveal the hidden text boxes before
+        #     calling axe.
+        conference_text = driver.find_element_by_css_selector(
+            '[data-test-meetings-list-min-5]'
+        )
+        meetings_page.scroll_into_view(conference_text)
+        meetings_page.register_button.click()
+        meetings_page.upload_button.click()
+        a11y.run_axe(driver, session, 'meetings')
+
+
+class TestMeetingDetailPage:
+    def test_accessibility(self, driver, session):
+        """To test the Meeting Detail Page, start at the Meetings Landing Page and then
+        scroll down to the meetings list table and click the title link for the first
+        meeting in the table to open the detail page for that meeting.
+        """
+        meetings_page = MeetingsPage(driver)
+        meetings_page.goto()
+        assert MeetingsPage(driver, verify=True)
+        search_bar = driver.find_element_by_css_selector(
+            'div[data-test-meetings-list-search]'
+        )
+        driver.execute_script('arguments[0].scrollIntoView();', search_bar)
+        meetings_page.top_meeting_link.click()
+        assert MeetingDetailPage(driver, verify=True)
+        # wait for project table to be loaded before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-submissions-list-item-title]')
+            )
+        )
+        a11y.run_axe(driver, session, 'mtngdet')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages in the OSF Meetings product area.

## Summary of Changes

- pages/meetings.py - update identity locator for Meeting Detail page, since old locator used a button that is not always on pages in Production.
- tests/test_a11y_meetings.py - new test that loads each of the pages associated with the OSF Meetings product area and then performs accessibility checks on each page. Meetings pages include: Meetings Landing Page and Meeting Detail Page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/meetings`

Run this test using
`tests/test_a11y_meetings.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2990: SEL: Accessibility - Create Meetings Test
https://openscience.atlassian.net/browse/ENG-2990
