### PR TITLE
[ENG-3168] - Create Collections Accessibility Test

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -284,6 +284,17 @@ def get_providers_list(session=None, type='preprints'):
     return session.get(url)['data']
 
 
+def get_provider(session=None, type='registrations', provider_id='osf'):
+    """Return the data for an individual provider. The default type is registrations but
+    it can also be used for a preprints or collections provider.  The default provider_id
+    is 'osf'
+    """
+    if not session:
+        session = get_default_session()
+    url = '/v2/providers/' + type + '/' + provider_id
+    return session.get(url)['data']
+
+
 def get_provider_submission_status(provider):
     """Return the boolean attribute `allow_submissions` from the dictionary object (provider)
     """

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -1,0 +1,52 @@
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+
+import settings
+from base.locators import Locator
+from pages.base import OSFBasePage
+
+
+class BaseCollectionPage(OSFBasePage):
+    """The base page from which all collection pages inherit.
+    """
+
+    base_url = settings.OSF_HOME + '/collections/'
+    url_addition = ''
+
+    def __init__(self, driver, verify=False, provider=None):
+        self.provider = provider
+        if provider:
+            self.provider_id = provider['id']
+            self.provider_name = provider['attributes']['name']
+
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        """Set the URL based on the provider domain.
+        """
+        return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
+
+
+class CollectionDiscoverPage(BaseCollectionPage):
+    url_addition = 'discover'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-test-provider-branding]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionSubmitPage(BaseCollectionPage):
+    url_addition = 'submit'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-test-collections-submit-sections]')
+    project_selector = Locator(
+        By.CSS_SELECTOR, 'span[class="ember-power-select-placeholder"]'
+    )
+    project_help_text = Locator(
+        By.CSS_SELECTOR, '.ember-power-select-option--search-message'
+    )
+    project_selector_project = Locator(By.CSS_SELECTOR, '.ember-power-select-option')
+    project_metadata_save = Locator(
+        By.CSS_SELECTOR, '[data-test-project-metadata-save-button]'
+    )

--- a/tests/test_a11y_collections.py
+++ b/tests/test_a11y_collections.py
@@ -1,0 +1,63 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from api import osf_api
+from components.accessibility import ApplyA11yRules as a11y
+from pages.collections import CollectionDiscoverPage, CollectionSubmitPage
+
+
+class TestCollectionDiscoverPages:
+    """This test will load the Discover page for each Collection Provider that exists in
+    an environment.
+    """
+
+    def providers():
+        """Return all collection providers.
+        """
+        return osf_api.get_providers_list(type='collections')
+
+    @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
+    def provider(self, request):
+        return request.param
+
+    def test_accessibility(self, session, driver, provider):
+        discover_page = CollectionDiscoverPage(driver, provider=provider)
+        discover_page.goto()
+        assert CollectionDiscoverPage(driver, verify=True)
+        discover_page.loading_indicator.here_then_gone()
+        page_name = 'cp_' + provider['id']
+        a11y.run_axe(driver, session, page_name)
+
+
+class TestCollectionSubmitPage:
+    """This test is for the Collection Submit page which is accessed by the "Add to
+    Collection" link in the navigation bar of a Collection Provider.  The Collection
+    Providers available in each environment are inconsistent.  So we are only accessing
+    the Submit page for the Character Lab Collection since this provider exists in every
+    environment.
+    """
+
+    @pytest.fixture
+    def provider(self, driver):
+        return osf_api.get_provider(type='collections', provider_id='characterlab')
+
+    def test_accessibility(
+        self, driver, session, provider, project_with_file, must_be_logged_in
+    ):
+        submit_page = CollectionSubmitPage(driver, provider=provider)
+        submit_page.goto()
+        assert CollectionSubmitPage(driver, verify=True)
+        # Continue process until Project contributors section is expanded before
+        #     calling axe
+        submit_page.project_selector.click()
+        submit_page.project_help_text.here_then_gone()
+        submit_page.project_selector_project.click()
+        submit_page.project_metadata_save.click()
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-project-contributors-list-item-name]')
+            )
+        )
+        a11y.run_axe(driver, session, 'collsub')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages in the OSF Collections product area.

## Summary of Changes

- api/osf_api.py - added new method - get_provider() - that returns the data for an individual provider from the OSF api. This method can be used for any of the provider types - collections, registrations, or preprints
- pages/collections.py - new page file with definitions for BaseCollectionPage, CollectionDiscoverPage, and CollectionSubmitPage
- tests/test_a11y_collections.py - new test that loads each of the pages associated with the OSF Collections product area and then performs accessibility checks on each page.  Collections pages include: Collections Discover Page (for each Collection Provider) and Collection Submit Page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/collections`

Run this test using
`tests/test_a11y_collections.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3168: SEL: Accessibility - Create Test for Collections Pages
https://openscience.atlassian.net/browse/ENG-3168
