### PR TITLE
[ENG-2988] - Create Registries Accessibility Test 

### DIFF
--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -7,12 +7,10 @@ from pages.base import OSFBasePage
 
 class MyRegistrationsPage(OSFBasePage):
     url = settings.OSF_HOME + '/registries/my-registrations/'
-    # identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Registries"]')
     identity = Locator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]'
     )
 
-    # drafts_tab = Locator(By.XPATH, '//a[text()="Drafts"]')
     drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
     no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
     draft_registration_title = Locator(

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -13,19 +13,23 @@ class MyRegistrationsPage(OSFBasePage):
 
     drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
     no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
+    create_a_registration_button_drafts = Locator(
+        By.CSS_SELECTOR, 'a[data-test-my-reg-drafts-add-new-button]'
+    )
     draft_registration_title = Locator(
         By.CSS_SELECTOR, 'a[data-analytics-name="view_registration"]'
     )
 
-    submissions_tab = Locator(By.XPATH, '//a[text()="Submitted"]')
+    submissions_tab = Locator(
+        By.CSS_SELECTOR, '[data-test-my-registrations-nav="submitted"]'
+    )
     no_submissions_message = Locator(
         By.CSS_SELECTOR, 'p[data-test-draft-list-no-registrations]'
     )
-    public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')
-
-    create_a_registration_button = GroupLocator(
-        By.XPATH, '//button[text()="Create a registration"]'
+    create_a_registration_button_submitted = Locator(
+        By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]'
     )
+    public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')
 
     draft_registration_cards = GroupLocator(
         By.CSS_SELECTOR, 'div[data-test-draft-registration-card]'

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -1,0 +1,44 @@
+from selenium.webdriver.common.by import By
+
+import settings
+from base.locators import GroupLocator, Locator
+from pages.base import OSFBasePage
+
+
+class MyRegistrationsPage(OSFBasePage):
+    url = settings.OSF_HOME + '/registries/my-registrations/'
+    # identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Registries"]')
+    identity = Locator(
+        By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]'
+    )
+
+    # drafts_tab = Locator(By.XPATH, '//a[text()="Drafts"]')
+    drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
+    no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
+    draft_registration_title = Locator(
+        By.CSS_SELECTOR, 'a[data-analytics-name="view_registration"]'
+    )
+
+    submissions_tab = Locator(By.XPATH, '//a[text()="Submitted"]')
+    no_submissions_message = Locator(
+        By.CSS_SELECTOR, 'p[data-test-draft-list-no-registrations]'
+    )
+    public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')
+
+    create_a_registration_button = GroupLocator(
+        By.XPATH, '//button[text()="Create a registration"]'
+    )
+
+    draft_registration_cards = GroupLocator(
+        By.CSS_SELECTOR, 'div[data-test-draft-registration-card]'
+    )
+
+    def get_first_draft_id_by_template(self, template_name):
+        for draft_card in self.draft_registration_cards:
+            template = draft_card.find_element_by_css_selector('[data-test-form-type]')
+            if template_name in template.text:
+                url = draft_card.find_element_by_css_selector(
+                    'a[data-analytics-name="view_registration"]'
+                ).get_attribute('href')
+                draft_id = url.split('drafts/', 1)[1]
+                return draft_id

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -99,8 +99,8 @@ class RegistriesModerationModeratorsPage(BaseRegistriesPage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-moderator-row]')
 
 
-class RegistriesModerationNotificationsPage(BaseRegistriesPage):
-    url_addition = 'moderation/notifications'
+class RegistriesModerationSettingsPage(BaseRegistriesPage):
+    url_addition = 'moderation/settings'
     identity = Locator(By.CSS_SELECTOR, '[data-test-subscription-list]')
 
 

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
@@ -8,14 +10,28 @@ from pages.base import GuidBasePage, OSFBasePage
 
 
 class BaseRegistriesPage(OSFBasePage):
-
-    # Components
+    base_url = settings.OSF_HOME + '/registries/'
+    url_addition = ''
     navbar = ComponentLocator(RegistriesNavbar)
+
+    def __init__(self, driver, verify=False, provider=None):
+        self.provider = provider
+        if provider:
+            self.provider_id = provider['id']
+            self.provider_name = provider['attributes']['name']
+
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        """Set the URL based on the provider
+        """
+        if self.provider and self.provider_id != 'osf':
+            return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
+        return self.base_url + self.url_addition
 
 
 class RegistriesLandingPage(BaseRegistriesPage):
-    url = settings.OSF_HOME + '/registries'
-
     identity = Locator(
         By.CSS_SELECTOR, '._RegistriesHeader_3zbd8x', settings.LONG_TIMEOUT
     )
@@ -23,11 +39,12 @@ class RegistriesLandingPage(BaseRegistriesPage):
 
 
 class RegistriesDiscoverPage(BaseRegistriesPage):
-    url = settings.OSF_HOME + '/registries/discover'
+    url_addition = 'discover'
 
     identity = Locator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]'
     )
+    search_box = Locator(By.ID, 'search')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
     osf_filter = Locator(
         By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]'
@@ -50,8 +67,79 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
 
 class RegistrationDetailPage(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-registration-title]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
 
 
 class RegistrationAddNewPage(BaseRegistriesPage):
-    url = settings.OSF_HOME + '/registries/osf/new'
-    identity = Locator(By.CLASS_NAME, 'Application__page', settings.LONG_TIMEOUT)
+    url_addition = 'new'
+    identity = Locator(
+        By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT
+    )
+
+    @property
+    def url(self):
+        """Have to override the url for the Add New Page since this page does
+        include 'osf' in the url for OSF Registries
+        """
+        if self.provider is None:
+            self.provider_id = 'osf'
+        return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
+
+
+class RegistriesModerationSubmissionsPage(BaseRegistriesPage):
+    url_addition = 'moderation/submissions'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type]')
+    no_registrations_message = Locator(
+        By.CSS_SELECTOR, '[data-test-registration-list-none]'
+    )
+
+
+class RegistriesModerationModeratorsPage(BaseRegistriesPage):
+    url_addition = 'moderation/moderators'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-moderator-row]')
+
+
+class RegistriesModerationNotificationsPage(BaseRegistriesPage):
+    url_addition = 'moderation/notifications'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-subscription-list]')
+
+
+class BaseRegistrationDraftPage(BaseRegistriesPage):
+    base_url = settings.OSF_HOME + '/registries/drafts/'
+    url_addition = ''
+
+    def __init__(self, driver, verify=False, draft_id=''):
+        self.draft_id = draft_id
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        return self.base_url + self.draft_id + '/' + self.url_addition
+
+
+class DraftRegistrationMetadataPage(BaseRegistrationDraftPage):
+    url_addition = 'metadata'
+    identity = Locator(
+        By.CSS_SELECTOR, 'div[data-test-metadata-title]', settings.LONG_TIMEOUT
+    )
+
+
+class DraftRegistrationGenericPage(BaseRegistrationDraftPage):
+    def __init__(self, driver, verify=False, draft_id='', url_addition=''):
+        self.draft_id = draft_id
+        self.url_addition = url_addition
+        super().__init__(driver, verify, draft_id)
+
+    identity = Locator(
+        By.CSS_SELECTOR, 'div[data-analytics-scope="Registries"]', settings.LONG_TIMEOUT
+    )
+    page_heading = Locator(By.CSS_SELECTOR, 'h2[data-test-page-heading]')
+
+
+class DraftRegistrationReviewPage(BaseRegistrationDraftPage):
+    url_addition = 'review'
+    identity = Locator(
+        By.CSS_SELECTOR,
+        'button[data-test-toggle-anchor-nav-button]',
+        settings.LONG_TIMEOUT,
+    )

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -62,7 +62,7 @@ class TestRegistrationDetailPage:
             # institutions as setup in the testing environments typically include the
             # specific environment in their names.  EX: The Center For Open Science [Stage2]
             if settings.STAGE1:
-                # need to drop the 1 since they usually just use 'Stage' instead of 'Stage1'
+                # Need to drop the 1 since they usually just use 'Stage' instead of 'Stage1'
                 environment = 'stage'
             else:
                 environment = settings.DOMAIN
@@ -72,7 +72,7 @@ class TestRegistrationDetailPage:
         discover_page.loading_indicator.here_then_gone()
         search_results = discover_page.search_results
         assert search_results
-        # open the first non-withdrawn registration in the search results
+        # Open the first non-withdrawn registration in the search results
         target_registration = discover_page.get_first_non_withdrawn_registration()
         target_registration.click()
         detail_page = RegistrationDetailPage(driver, verify=True)
@@ -80,14 +80,14 @@ class TestRegistrationDetailPage:
         a11y.run_axe(driver, session, 'regdet')
 
 
-# user two with registrations is not setup in production
+# User two with registrations is not setup in production
 @markers.dont_run_on_prod
 class TestMyRegistrationsPage:
     def test_accessibility(self, driver, session, must_be_logged_in_as_user_two):
         my_registrations_page = MyRegistrationsPage(driver)
         my_registrations_page.goto()
         assert MyRegistrationsPage(driver, verify=True)
-        # wait for node cards to be visible before calling axe
+        # Wait for node cards to be visible before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '[data-test-node-card]'))
         )
@@ -102,7 +102,7 @@ class TestAddNewRegistrationPage:
         a11y.run_axe(driver, session, 'addnewreg')
 
 
-# user two with registrations is not setup in production
+# User two with registrations is not setup in production
 @markers.dont_run_on_prod
 class TestDraftRegistrationPages:
     @pytest.fixture()
@@ -114,7 +114,7 @@ class TestDraftRegistrationPages:
         my_registrations_page = MyRegistrationsPage(driver)
         my_registrations_page.goto()
         my_registrations_page.drafts_tab.click()
-        # wait for draft cards to load on page
+        # Wait for draft cards to load on page
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-draft-registration-card]')
@@ -145,7 +145,7 @@ class TestDraftRegistrationPages:
         Open-Ended Registration and then capture it's draft id so that we can use it to
         navigate to it's Summary page.
         """
-        # capture the draft id from the first Open-Ended Registration that is listed
+        # Capture the draft id from the first Open-Ended Registration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Open-Ended Registration'
         )
@@ -154,7 +154,7 @@ class TestDraftRegistrationPages:
         )
         summary_page.goto()
         assert summary_page.page_heading.text == 'Summary'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -172,7 +172,7 @@ class TestDraftRegistrationPages:
         Qualitative Preregistration and then capture it's draft id so that we can use it to
         navigate to it's Study Information page.
         """
-        # capture the draft id from the first Qualitative Preregistration that is listed
+        # Capture the draft id from the first Qualitative Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Qualitative Preregistration'
         )
@@ -193,7 +193,7 @@ class TestDraftRegistrationPages:
         Qualitative Preregistration and then capture it's draft id so that we can use it to
         navigate to it's Study Information page.
         """
-        # capture the draft id from the first Qualitative Preregistration that is listed
+        # Capture the draft id from the first Qualitative Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Qualitative Preregistration'
         )
@@ -214,7 +214,7 @@ class TestDraftRegistrationPages:
         find the card for a Qualitative Preregistration and then capture it's draft
         id so that we can use it to navigate to it's Miscellaneous page.
         """
-        # capture the draft id from the first Qualitative Preregistration that is listed
+        # Capture the draft id from the first Qualitative Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Qualitative Preregistration'
         )
@@ -235,7 +235,7 @@ class TestDraftRegistrationPages:
         Preregistration and then capture it's draft id so that we can use it to navigate
         to it's Design Plan page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first OSF Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'OSF Preregistration'
         )
@@ -244,7 +244,7 @@ class TestDraftRegistrationPages:
         )
         design_plan_page.goto()
         assert design_plan_page.page_heading.text == 'Design Plan'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -262,7 +262,7 @@ class TestDraftRegistrationPages:
         Preregistration and then capture it's draft id so that we can use it to navigate
         to it's Design Plan page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first OSF Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'OSF Preregistration'
         )
@@ -271,7 +271,7 @@ class TestDraftRegistrationPages:
         )
         sampling_plan_page.goto()
         assert sampling_plan_page.page_heading.text == 'Sampling Plan'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -287,7 +287,7 @@ class TestDraftRegistrationPages:
         Preregistration and then capture it's draft id so that we can use it to navigate
         to it's Variables page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first OSF Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'OSF Preregistration'
         )
@@ -296,7 +296,7 @@ class TestDraftRegistrationPages:
         )
         variables_page.goto()
         assert variables_page.page_heading.text == 'Variables'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -314,7 +314,7 @@ class TestDraftRegistrationPages:
         Preregistration and then capture it's draft id so that we can use it to navigate
         to it's Analysis Plan page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first OSF Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'OSF Preregistration'
         )
@@ -323,7 +323,7 @@ class TestDraftRegistrationPages:
         )
         analysis_plan_page.goto()
         assert analysis_plan_page.page_heading.text == 'Analysis Plan'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -341,7 +341,8 @@ class TestDraftRegistrationPages:
         a Registered Report Protocol Preregistration and then capture it's draft id so that we
         can use it to navigate to it's Publication Information page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first Registered Report Protocol Preregistration
+        # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Registered Report Protocol Preregistration'
         )
@@ -364,7 +365,8 @@ class TestDraftRegistrationPages:
         Registered Report Protocol Preregistration and then capture it's draft id so that we
         can use it to navigate to it's Publication Information page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first Registered Report Protocol Preregistration
+        # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Registered Report Protocol Preregistration'
         )
@@ -373,7 +375,7 @@ class TestDraftRegistrationPages:
         )
         manuscript_page.goto()
         assert manuscript_page.page_heading.text == 'Manuscript'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -389,7 +391,7 @@ class TestDraftRegistrationPages:
         the card for an Registered Report Protocol Preregistration and then capture it's
         draft id so that we can use it to navigate to it's Other page.
         """
-        # capture the draft id from the first Registered Report Protocol Preregistration
+        # Capture the draft id from the first Registered Report Protocol Preregistration
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Registered Report Protocol Preregistration'
@@ -399,7 +401,7 @@ class TestDraftRegistrationPages:
         )
         other_page.goto()
         assert other_page.page_heading.text == 'Other'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -419,7 +421,7 @@ class TestDraftRegistrationPages:
         can use it to navigate to it's Preregistration Template from AsPredicted.org
         page.
         """
-        # capture the draft id from the first Preregistration Template from AsPredicted.org
+        # Capture the draft id from the first Preregistration Template from AsPredicted.org
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Preregistration Template from AsPredicted.org'
@@ -448,7 +450,7 @@ class TestDraftRegistrationPages:
         we can use it to navigate to it's OSF-Standard Pre-Data Collection Registration
         page.
         """
-        # capture the draft id from the first OSF-Standard Pre-Data Collection Registration
+        # Capture the draft id from the first OSF-Standard Pre-Data Collection Registration
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'OSF-Standard Pre-Data Collection Registration'
@@ -477,7 +479,7 @@ class TestDraftRegistrationPages:
         so that we can use it to navigate to it's Hypotheses - Essential elements
         page.
         """
-        # capture the draft id from the first Pre-Registration in Social Psychology
+        # Capture the draft id from the first Pre-Registration in Social Psychology
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Pre-Registration in Social Psychology'
@@ -502,7 +504,7 @@ class TestDraftRegistrationPages:
         Psychology draft and then capture it's draft id so that we can use it to
         navigate to it's Recommended elements page.
         """
-        # capture the draft id from the first Pre-Registration in Social Psychology
+        # Capture the draft id from the first Pre-Registration in Social Psychology
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Pre-Registration in Social Psychology'
@@ -512,7 +514,7 @@ class TestDraftRegistrationPages:
         )
         recommended_elements_page.goto()
         assert recommended_elements_page.page_heading.text == 'Recommended elements'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -531,7 +533,7 @@ class TestDraftRegistrationPages:
         Pre-Registration in Social Psychology draft and then capture it's draft id
         so that we can use it to navigate to it's Methods - Essential elements page.
         """
-        # capture the draft id from the first Pre-Registration in Social Psychology
+        # Capture the draft id from the first Pre-Registration in Social Psychology
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Pre-Registration in Social Psychology'
@@ -541,7 +543,7 @@ class TestDraftRegistrationPages:
         )
         methods_page.goto()
         assert methods_page.page_heading.text == 'B. Methods - Essential elements'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -561,7 +563,7 @@ class TestDraftRegistrationPages:
         so that we can use it to navigate to it's Analysis Plan - Essential elements
         page.
         """
-        # capture the draft id from the first Pre-Registration in Social Psychology
+        # Capture the draft id from the first Pre-Registration in Social Psychology
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Pre-Registration in Social Psychology'
@@ -589,7 +591,7 @@ class TestDraftRegistrationPages:
         Psychology draft and then capture it's draft id so that we can use it to
         navigate to it's Final questions page.
         """
-        # capture the draft id from the first Pre-Registration in Social Psychology
+        # Capture the draft id from the first Pre-Registration in Social Psychology
         # that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Pre-Registration in Social Psychology'
@@ -613,7 +615,7 @@ class TestDraftRegistrationPages:
         and then capture it's draft id so that we can use it to navigate to it's
         The Nature of the Effect page.
         """
-        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Capture the draft id from the first Replication Recipe (Brandt et al., 2013):
         # Pre-Registration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Replication Recipe (Brandt et al., 2013): Pre-Registration'
@@ -637,7 +639,7 @@ class TestDraftRegistrationPages:
         capture it's draft id so that we can use it to navigate to it's Designing
         the Replication Study page.
         """
-        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Capture the draft id from the first Replication Recipe (Brandt et al., 2013):
         # Pre-Registration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Replication Recipe (Brandt et al., 2013): Pre-Registration'
@@ -662,7 +664,7 @@ class TestDraftRegistrationPages:
         use it to navigate to it's Documenting Differences between the Original and
         Replication Study page.
         """
-        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Capture the draft id from the first Replication Recipe (Brandt et al., 2013):
         # Pre-Registration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Replication Recipe (Brandt et al., 2013): Pre-Registration'
@@ -691,7 +693,7 @@ class TestDraftRegistrationPages:
         then capture it's draft id so that we can use it to navigate to it's Analysis
         and Replication Evaluation page.
         """
-        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Capture the draft id from the first Replication Recipe (Brandt et al., 2013):
         # Pre-Registration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Replication Recipe (Brandt et al., 2013): Pre-Registration'
@@ -720,7 +722,7 @@ class TestDraftRegistrationPages:
         then capture it's draft id so that we can use it to navigate to it's
         Registering the Replication Attempt page.
         """
-        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Capture the draft id from the first Replication Recipe (Brandt et al., 2013):
         # Post-Completion that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Replication Recipe (Brandt et al., 2013): Post-Completion'
@@ -748,7 +750,7 @@ class TestDraftRegistrationPages:
         (Brandt et al., 2013): Post-Completion draft and then capture it's draft id
         so that we can use it to navigate to it's Reporting the Replication page.
         """
-        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Capture the draft id from the first Replication Recipe (Brandt et al., 2013):
         # Post-Completion that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Replication Recipe (Brandt et al., 2013): Post-Completion'
@@ -773,7 +775,7 @@ class TestDraftRegistrationPages:
         draft and then capture it's draft id so that we can use it to navigate to
         it's Data Description page.
         """
-        # capture the draft id from the first Secondary Data Preregistration that
+        # Capture the draft id from the first Secondary Data Preregistration that
         # is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Secondary Data Preregistration'
@@ -783,7 +785,7 @@ class TestDraftRegistrationPages:
         )
         data_description_page.goto()
         assert data_description_page.page_heading.text == 'Data Description'
-        # wait for file widget to load before calling axe
+        # Wait for file widget to load before calling axe
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
@@ -802,7 +804,7 @@ class TestDraftRegistrationPages:
         draft and then capture it's draft id so that we can use it to navigate to
         it's Knowledge of Data page.
         """
-        # capture the draft id from the first Secondary Data Preregistration that
+        # Capture the draft id from the first Secondary Data Preregistration that
         # is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'Secondary Data Preregistration'
@@ -824,7 +826,7 @@ class TestDraftRegistrationPages:
         Preregistration and then capture it's draft id so that we can use it to navigate
         to it's Other page.
         """
-        # capture the draft id from the first OSF Preregistration that is listed
+        # Capture the draft id from the first OSF Preregistration that is listed
         draft_id = my_registrations_page.get_first_draft_id_by_template(
             'OSF Preregistration'
         )
@@ -859,7 +861,7 @@ class TestBrandedRegistrationsProviders:
         a11y.run_axe(driver, session, page_name)
 
 
-# we do not currently have a user setup as a moderator for any of the registries in production
+# We do not currently have a user setup as an administrator for any of the registries in production
 @markers.dont_run_on_prod
 class TestModerationPages:
     """To test the Moderation pages we must login as a user that has been setup as an
@@ -880,7 +882,7 @@ class TestModerationPages:
         )
         submissions_page.goto()
         assert RegistriesModerationSubmissionsPage(driver, verify=True)
-        # wait for registration table to load before calling axe
+        # Wait for registration table to load before calling axe
         if submissions_page.no_registrations_message.absent():
             WebDriverWait(driver, 5).until(
                 EC.presence_of_element_located(
@@ -895,7 +897,7 @@ class TestModerationPages:
         moderators_page = RegistriesModerationModeratorsPage(driver, provider=provider)
         moderators_page.goto()
         assert RegistriesModerationModeratorsPage(driver, verify=True)
-        # wait for moderators table to load before calling axe
+        # Wait for moderators table to load before calling axe
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-moderator-row]')
@@ -909,7 +911,7 @@ class TestModerationPages:
         settings_page = RegistriesModerationSettingsPage(driver, provider=provider)
         settings_page.goto()
         assert RegistriesModerationSettingsPage(driver, verify=True)
-        # wait for notifications list to load before calling axe
+        # Wait for notifications list to load before calling axe
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-subscription-list-row]')

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -18,7 +18,7 @@ from pages.registries import (
     RegistriesDiscoverPage,
     RegistriesLandingPage,
     RegistriesModerationModeratorsPage,
-    RegistriesModerationNotificationsPage,
+    RegistriesModerationSettingsPage,
     RegistriesModerationSubmissionsPage,
 )
 
@@ -862,9 +862,9 @@ class TestBrandedRegistrationsProviders:
 # we do not currently have a user setup as a moderator for any of the registries in production
 @markers.dont_run_on_prod
 class TestModerationPages:
-    """To test the Moderation pages we must login as a user that has been setup as a
-    moderator for one of the registry providers that has moderation enabled.  We are
-    using the egap registry since it exists in all testing environments and has the
+    """To test the Moderation pages we must login as a user that has been setup as an
+    administrator for one of the registry providers that has moderation enabled.  We
+    are using the egap registry since it exists in all testing environments and has the
     moderation process enabled in each environment.
     """
 
@@ -903,18 +903,16 @@ class TestModerationPages:
         )
         a11y.run_axe(driver, session, 'regmodmod')
 
-    def test_accessibility_moderation_notifications(
+    def test_accessibility_moderation_settings(
         self, driver, session, provider, must_be_logged_in
     ):
-        notifications_page = RegistriesModerationNotificationsPage(
-            driver, provider=provider
-        )
-        notifications_page.goto()
-        assert RegistriesModerationNotificationsPage(driver, verify=True)
+        settings_page = RegistriesModerationSettingsPage(driver, provider=provider)
+        settings_page.goto()
+        assert RegistriesModerationSettingsPage(driver, verify=True)
         # wait for notifications list to load before calling axe
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-subscription-list-row]')
             )
         )
-        a11y.run_axe(driver, session, 'regmodnot')
+        a11y.run_axe(driver, session, 'regmodset')

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -1,0 +1,920 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+import markers
+import settings
+from api import osf_api
+from components.accessibility import ApplyA11yRules as a11y
+from pages.registrations import MyRegistrationsPage
+from pages.registries import (
+    DraftRegistrationGenericPage,
+    DraftRegistrationMetadataPage,
+    DraftRegistrationReviewPage,
+    RegistrationAddNewPage,
+    RegistrationDetailPage,
+    RegistriesDiscoverPage,
+    RegistriesLandingPage,
+    RegistriesModerationModeratorsPage,
+    RegistriesModerationNotificationsPage,
+    RegistriesModerationSubmissionsPage,
+)
+
+
+class TestRegistriesLandingPage:
+    def test_accessibility(self, driver, session):
+        landing_page = RegistriesLandingPage(driver)
+        landing_page.goto()
+        assert RegistriesLandingPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'registries')
+
+
+class TestRegistriesDiscoverPage:
+    """This test is for the OSF Registries Discover Page. The other Branded Provider
+    Registries Discover pages will be tested below.
+    """
+
+    def test_accessibility(self, driver, session):
+        discover_page = RegistriesDiscoverPage(driver)
+        discover_page.goto()
+        assert RegistriesDiscoverPage(driver, verify=True)
+        discover_page.loading_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'regdisc')
+
+
+class TestRegistrationDetailPage:
+    """This test is for the Registration Detail Page for a submitted registration. It
+    accesses a submitted registration from the search results on the Registries Discover
+    page.
+    """
+
+    def test_accessibility(self, driver, session):
+        discover_page = RegistriesDiscoverPage(driver)
+        discover_page.goto()
+        assert RegistriesDiscoverPage(driver, verify=True)
+        if not settings.PRODUCTION:
+            # Since all of the testing environments use the same SHARE server, we need
+            # to enter a value in the search input box that will ensure that the results
+            # are specific to the current environment.  We can do this by searching for
+            # the test environment in the affiliations metadata field.  The affiliated
+            # institutions as setup in the testing environments typically include the
+            # specific environment in their names.  EX: The Center For Open Science [Stage2]
+            if settings.STAGE1:
+                # need to drop the 1 since they usually just use 'Stage' instead of 'Stage1'
+                environment = 'stage'
+            else:
+                environment = settings.DOMAIN
+            search_text = 'affiliations:' + environment
+            discover_page.search_box.send_keys_deliberately(search_text)
+            discover_page.search_box.send_keys(Keys.ENTER)
+        discover_page.loading_indicator.here_then_gone()
+        search_results = discover_page.search_results
+        assert search_results
+        # open the first non-withdrawn registration in the search results
+        target_registration = discover_page.get_first_non_withdrawn_registration()
+        target_registration.click()
+        detail_page = RegistrationDetailPage(driver, verify=True)
+        detail_page.loading_indicator.here_then_gone()
+        a11y.run_axe(driver, session, 'regdet')
+
+
+# user two with registrations is not setup in production
+@markers.dont_run_on_prod
+class TestMyRegistrationsPage:
+    def test_accessibility(self, driver, session, must_be_logged_in_as_user_two):
+        my_registrations_page = MyRegistrationsPage(driver)
+        my_registrations_page.goto()
+        assert MyRegistrationsPage(driver, verify=True)
+        # wait for node cards to be visible before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, '[data-test-node-card]'))
+        )
+        a11y.run_axe(driver, session, 'myreg')
+
+
+class TestAddNewRegistrationPage:
+    def test_accessibility(self, driver, session, must_be_logged_in):
+        add_new_registration_page = RegistrationAddNewPage(driver)
+        add_new_registration_page.goto()
+        assert RegistrationAddNewPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'addnewreg')
+
+
+# user two with registrations is not setup in production
+@markers.dont_run_on_prod
+class TestDraftRegistrationPages:
+    @pytest.fixture()
+    def my_registrations_page(self, driver, must_be_logged_in_as_user_two):
+        """Fixture that logs in as a user that already has draft registrations created
+        for the various templates/schemas and navigates to the My Registrations page
+        from which the desired draft registration type can be selected.
+        """
+        my_registrations_page = MyRegistrationsPage(driver)
+        my_registrations_page.goto()
+        my_registrations_page.drafts_tab.click()
+        # wait for draft cards to load on page
+        WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-draft-registration-card]')
+            )
+        )
+        draft_cards = my_registrations_page.draft_registration_cards
+        assert draft_cards
+        return my_registrations_page
+
+    def test_accessibility_metadata_page(self, driver, session, my_registrations_page):
+        """This test is for checking the accessibility of the Draft Registration Metadata
+        page.  We can just pick the first draft registration that is listed, since the
+        Metadata page is the same for all schemas.
+        """
+        # capture draft id from link url of 1st draft title and use that to go to page
+        url = my_registrations_page.draft_registration_title.get_attribute('href')
+        draft_id = url.split('drafts/', 1)[1]
+        metadata_page = DraftRegistrationMetadataPage(driver, draft_id=draft_id)
+        metadata_page.goto()
+        assert DraftRegistrationMetadataPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'drftregmeta')
+
+    def test_accessibility_summary_page(self, driver, session, my_registrations_page):
+        """This test is for checking the accessibility of the Draft Registration Summary
+        Page which is typically the second page on an Open-Ended Registration template.
+        Since the user also has other types of draft registrations, we must search through
+        the cards on the Drafts tab of the My Registrations page and find the card for an
+        Open-Ended Registration and then capture it's draft id so that we can use it to
+        navigate to it's Summary page.
+        """
+        # capture the draft id from the first Open-Ended Registration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Open-Ended Registration'
+        )
+        summary_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='1-summary'
+        )
+        summary_page.goto()
+        assert summary_page.page_heading.text == 'Summary'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregsum')
+
+    def test_accessibility_study_information_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Study
+        Information Page which is the second page on a Qualitative Preregistration template.
+        Since the user also has other types of draft registrations, we must search through
+        the cards on the Drafts tab of the My Registrations page and find the card for a
+        Qualitative Preregistration and then capture it's draft id so that we can use it to
+        navigate to it's Study Information page.
+        """
+        # capture the draft id from the first Qualitative Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Qualitative Preregistration'
+        )
+        study_information_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='1-study-information'
+        )
+        study_information_page.goto()
+        assert study_information_page.page_heading.text == 'Study Information'
+        a11y.run_axe(driver, session, 'drftregstudy')
+
+    def test_accessibility_data_collection_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Data
+        Collection Page which is the fourth page on a Qualitative Preregistration template.
+        Since the user also has other types of draft registrations, we must search through
+        the cards on the Drafts tab of the My Registrations page and find the card for a
+        Qualitative Preregistration and then capture it's draft id so that we can use it to
+        navigate to it's Study Information page.
+        """
+        # capture the draft id from the first Qualitative Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Qualitative Preregistration'
+        )
+        data_collection_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='3-data-collection'
+        )
+        data_collection_page.goto()
+        assert data_collection_page.page_heading.text == 'Data Collection'
+        a11y.run_axe(driver, session, 'drftregdatacol')
+
+    def test_accessibility_miscellaneous_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Miscellaneous Page which is the sixth page on a Qualitative Preregistration
+        template.  Since the user also has other types of draft registrations, we must
+        search through the cards on the Drafts tab of the My Registrations page and
+        find the card for a Qualitative Preregistration and then capture it's draft
+        id so that we can use it to navigate to it's Miscellaneous page.
+        """
+        # capture the draft id from the first Qualitative Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Qualitative Preregistration'
+        )
+        miscellaneous_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='5-miscellaneous'
+        )
+        miscellaneous_page.goto()
+        assert miscellaneous_page.page_heading.text == 'Miscellaneous'
+        a11y.run_axe(driver, session, 'drftregmisc')
+
+    def test_accessibility_design_plan_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Design
+        Plan Page which is the third page on an OSF Preregistration template.  Since the
+        user also has other types of draft registrations, we must search through the cards
+        on the Drafts tab of the My Registrations page and find the card for an OSF
+        Preregistration and then capture it's draft id so that we can use it to navigate
+        to it's Design Plan page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'OSF Preregistration'
+        )
+        design_plan_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='2-design-plan'
+        )
+        design_plan_page.goto()
+        assert design_plan_page.page_heading.text == 'Design Plan'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregdesign')
+
+    def test_accessibility_sampling_plan_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Sampling
+        Plan Page which is the fourth page on an OSF Preregistration template.  Since the
+        user also has other types of draft registrations, we must search through the cards
+        on the Drafts tab of the My Registrations page and find the card for an OSF
+        Preregistration and then capture it's draft id so that we can use it to navigate
+        to it's Design Plan page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'OSF Preregistration'
+        )
+        sampling_plan_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='3-sampling-plan'
+        )
+        sampling_plan_page.goto()
+        assert sampling_plan_page.page_heading.text == 'Sampling Plan'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregsampling')
+
+    def test_accessibility_variables_page(self, driver, session, my_registrations_page):
+        """This test is for checking the accessibility of the Draft Registration Variables
+        Page which is the fifth page on an OSF Preregistration template.  Since the user
+        also has other types of draft registrations, we must search through the cards on
+        the Drafts tab of the My Registrations page and find the card for an OSF
+        Preregistration and then capture it's draft id so that we can use it to navigate
+        to it's Variables page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'OSF Preregistration'
+        )
+        variables_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='4-variables'
+        )
+        variables_page.goto()
+        assert variables_page.page_heading.text == 'Variables'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregvariables')
+
+    def test_accessibility_analysis_plan_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Analysis
+        Plan Page which is the sixth page on an OSF Preregistration template.  Since the
+        user also has other types of draft registrations, we must search through the cards
+        on the Drafts tab of the My Registrations page and find the card for an OSF
+        Preregistration and then capture it's draft id so that we can use it to navigate
+        to it's Analysis Plan page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'OSF Preregistration'
+        )
+        analysis_plan_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='5-analysis-plan'
+        )
+        analysis_plan_page.goto()
+        assert analysis_plan_page.page_heading.text == 'Analysis Plan'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftreganalysis')
+
+    def test_accessibility_publication_information_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Publication
+        Information Page which is the second page on a Registered Report Protocol Preregistration
+        template.  Since the user also has other types of draft registrations, we must search
+        through the cards on the Drafts tab of the My Registrations page and find the card for
+        a Registered Report Protocol Preregistration and then capture it's draft id so that we
+        can use it to navigate to it's Publication Information page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Registered Report Protocol Preregistration'
+        )
+        publication_information_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='1-publication-information'
+        )
+        publication_information_page.goto()
+        assert (
+            publication_information_page.page_heading.text == 'Publication Information'
+        )
+        a11y.run_axe(driver, session, 'drftregpubinfo')
+
+    def test_accessibility_manuscript_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration Manuscript
+        Page which is the second page on a Registered Report Protocol Preregistration template.
+        Since the user also has other types of draft registrations, we must search through
+        the cards on the Drafts tab of the My Registrations page and find the card for a
+        Registered Report Protocol Preregistration and then capture it's draft id so that we
+        can use it to navigate to it's Publication Information page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Registered Report Protocol Preregistration'
+        )
+        manuscript_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='2-manuscript'
+        )
+        manuscript_page.goto()
+        assert manuscript_page.page_heading.text == 'Manuscript'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregmnscrpt')
+
+    def test_accessibility_other_page(self, driver, session, my_registrations_page):
+        """This test is for checking the accessibility of the Draft Registration Other
+        Page which is the fourth page on a Registered Report Protocol Preregistration
+        template.  Since the user also has other types of draft registrations, we must
+        search through the cards on the Drafts tab of the My Registrations page and find
+        the card for an Registered Report Protocol Preregistration and then capture it's
+        draft id so that we can use it to navigate to it's Other page.
+        """
+        # capture the draft id from the first Registered Report Protocol Preregistration
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Registered Report Protocol Preregistration'
+        )
+        other_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='3-other'
+        )
+        other_page.goto()
+        assert other_page.page_heading.text == 'Other'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregother')
+
+    def test_accessibility_prereg_template_aspredicted_org_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Preregistration Template from AsPredicted.org Page which is the second page on
+        a Preregistration Template from AsPredicted.org template.  Since the user also
+        has other types of draft registrations, we must search through the cards on the
+        Drafts tab of the My Registrations page and find the card for a Preregistration
+        Template from AsPredicted.org draft and then capture it's draft id so that we
+        can use it to navigate to it's Preregistration Template from AsPredicted.org
+        page.
+        """
+        # capture the draft id from the first Preregistration Template from AsPredicted.org
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Preregistration Template from AsPredicted.org'
+        )
+        prereg_template_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='1-preregistration-template-from-aspredictedorg',
+        )
+        prereg_template_page.goto()
+        assert (
+            prereg_template_page.page_heading.text
+            == 'Preregistration Template from AsPredicted.org'
+        )
+        a11y.run_axe(driver, session, 'drftregasprdct')
+
+    def test_accessibility_osf_standard_predata_collection_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        OSF-Standard Pre-Data Collection Registration Page which is the second page on
+        an OSF-Standard Pre-Data Collection Registration template.  Since the user also
+        has other types of draft registrations, we must search through the cards on the
+        Drafts tab of the My Registrations page and find the card for an OSF-Standard
+        Pre-Data Collection Registration draft and then capture it's draft id so that
+        we can use it to navigate to it's OSF-Standard Pre-Data Collection Registration
+        page.
+        """
+        # capture the draft id from the first OSF-Standard Pre-Data Collection Registration
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'OSF-Standard Pre-Data Collection Registration'
+        )
+        predata_collection_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='1-osf-standard-pre-data-collection-registration',
+        )
+        predata_collection_page.goto()
+        assert (
+            predata_collection_page.page_heading.text
+            == 'OSF-Standard Pre-Data Collection Registration'
+        )
+        a11y.run_axe(driver, session, 'drftregpredata')
+
+    def test_accessibility_hypotheses_essential_elements_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Hypotheses - Essential elements Page which is the second page on a
+        Pre-Registration in Social Psychology template.  Since the user also has
+        other types of draft registrations, we must search through the cards on the
+        Drafts tab of the My Registrations page and find the card for a
+        Pre-Registration in Social Psychology draft and then capture it's draft id
+        so that we can use it to navigate to it's Hypotheses - Essential elements
+        page.
+        """
+        # capture the draft id from the first Pre-Registration in Social Psychology
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Pre-Registration in Social Psychology'
+        )
+        hypotheses_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='1-a-hypotheses---essential-elements',
+        )
+        hypotheses_page.goto()
+        assert hypotheses_page.page_heading.text == 'A. Hypotheses - Essential elements'
+        a11y.run_axe(driver, session, 'drftreghypotheses')
+
+    def test_accessibility_recommended_elements_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Recommended elements Page which is the third page on a Pre-Registration in
+        Social Psychology template.  Since the user also has other types of draft
+        registrations, we must search through the cards on the Drafts tab of the My
+        Registrations page and find the card for a Pre-Registration in Social
+        Psychology draft and then capture it's draft id so that we can use it to
+        navigate to it's Recommended elements page.
+        """
+        # capture the draft id from the first Pre-Registration in Social Psychology
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Pre-Registration in Social Psychology'
+        )
+        recommended_elements_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='2-recommended-elements',
+        )
+        recommended_elements_page.goto()
+        assert recommended_elements_page.page_heading.text == 'Recommended elements'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregrecelems')
+
+    def test_accessibility_methods_essential_elements_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Methods - Essential elements Page which is the fourth page on a
+        Pre-Registration in Social Psychology template.  Since the user also has
+        other types of draft registrations, we must search through the cards on the
+        Drafts tab of the My Registrations page and find the card for a
+        Pre-Registration in Social Psychology draft and then capture it's draft id
+        so that we can use it to navigate to it's Methods - Essential elements page.
+        """
+        # capture the draft id from the first Pre-Registration in Social Psychology
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Pre-Registration in Social Psychology'
+        )
+        methods_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='3-b-methods---essential-elements',
+        )
+        methods_page.goto()
+        assert methods_page.page_heading.text == 'B. Methods - Essential elements'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregmethods')
+
+    def test_accessibility_analysis_plan_essential_elements_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Analysis Plan - Essential elements Page which is the sixth page on a
+        Pre-Registration in Social Psychology template.  Since the user also has
+        other types of draft registrations, we must search through the cards on the
+        Drafts tab of the My Registrations page and find the card for a
+        Pre-Registration in Social Psychology draft and then capture it's draft id
+        so that we can use it to navigate to it's Analysis Plan - Essential elements
+        page.
+        """
+        # capture the draft id from the first Pre-Registration in Social Psychology
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Pre-Registration in Social Psychology'
+        )
+        analysis_plan_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='5-c-analysis-plan---essential-elements',
+        )
+        analysis_plan_page.goto()
+        assert (
+            analysis_plan_page.page_heading.text
+            == 'C. Analysis plan - Essential elements'
+        )
+        a11y.run_axe(driver, session, 'drftregaplnelems')
+
+    def test_accessibility_final_questions_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Final questions Page which is the eighth page on a Pre-Registration in
+        Social Psychology template.  Since the user also has other types of draft
+        registrations, we must search through the cards on the Drafts tab of the
+        My Registrations page and find the card for a Pre-Registration in Social
+        Psychology draft and then capture it's draft id so that we can use it to
+        navigate to it's Final questions page.
+        """
+        # capture the draft id from the first Pre-Registration in Social Psychology
+        # that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Pre-Registration in Social Psychology'
+        )
+        final_questions_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='7-final-questions'
+        )
+        final_questions_page.goto()
+        assert final_questions_page.page_heading.text == 'Final questions'
+        a11y.run_axe(driver, session, 'drftregfnlqustns')
+
+    def test_accessibility_nature_of_the_effect_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        The Nature of the Effect Page which is the second page on a Replication
+        Recipe (Brandt et al., 2013): Pre-Registration template.  Since the user
+        also has other types of draft registrations, we must search through the
+        cards on the Drafts tab of the My Registrations page and find the card
+        for a Replication Recipe (Brandt et al., 2013): Pre-Registration draft
+        and then capture it's draft id so that we can use it to navigate to it's
+        The Nature of the Effect page.
+        """
+        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Pre-Registration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Replication Recipe (Brandt et al., 2013): Pre-Registration'
+        )
+        nature_effect_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='1-the-nature-of-the-effect'
+        )
+        nature_effect_page.goto()
+        assert nature_effect_page.page_heading.text == 'The Nature of the Effect'
+        a11y.run_axe(driver, session, 'drftregnateff')
+
+    def test_accessibility_designing_replication_study_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Designing the Replication Study Page which is the third page on a Replication
+        Recipe (Brandt et al., 2013): Pre-Registration template.  Since the user also
+        has other types of draft registrations, we must search through the cards on
+        the Drafts tab of the My Registrations page and find the card for a
+        Replication Recipe (Brandt et al., 2013): Pre-Registration draft and then
+        capture it's draft id so that we can use it to navigate to it's Designing
+        the Replication Study page.
+        """
+        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Pre-Registration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Replication Recipe (Brandt et al., 2013): Pre-Registration'
+        )
+        design_study_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='2-designing-the-replication-study'
+        )
+        design_study_page.goto()
+        assert design_study_page.page_heading.text == 'Designing the Replication Study'
+        a11y.run_axe(driver, session, 'drftregdesrepstdy')
+
+    def test_accessibility_documenting_differences_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Documenting Differences between the Original and Replication Study Page which
+        is the fourth page on a Replication Recipe (Brandt et al., 2013):
+        Pre-Registration template.  Since the user also has other types of draft
+        registrations, we must search through the cards on the Drafts tab of the My
+        Registrations page and find the card for a Replication Recipe (Brandt et al.,
+        2013): Pre-Registration draft and then capture it's draft id so that we can
+        use it to navigate to it's Documenting Differences between the Original and
+        Replication Study page.
+        """
+        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Pre-Registration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Replication Recipe (Brandt et al., 2013): Pre-Registration'
+        )
+        documenting_differences_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='3-documenting-differences-between-the-original-and-replication-study',
+        )
+        documenting_differences_page.goto()
+        assert (
+            documenting_differences_page.page_heading.text
+            == 'Documenting Differences between the Original and Replication Study'
+        )
+        a11y.run_axe(driver, session, 'drftregdocdiff')
+
+    def test_accessibility_analysis_replication_evaluation_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Analysis and Replication Evaluation Page which is the fifth page on a
+        Replication Recipe (Brandt et al., 2013): Pre-Registration template.  Since
+        the user also has other types of draft registrations, we must search through
+        the cards on the Drafts tab of the My Registrations page and find the card
+        for a Replication Recipe (Brandt et al., 2013): Pre-Registration draft and
+        then capture it's draft id so that we can use it to navigate to it's Analysis
+        and Replication Evaluation page.
+        """
+        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Pre-Registration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Replication Recipe (Brandt et al., 2013): Pre-Registration'
+        )
+        analysis_replication_eval_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='4-analysis-and-replication-evaluation',
+        )
+        analysis_replication_eval_page.goto()
+        assert (
+            analysis_replication_eval_page.page_heading.text
+            == 'Analysis and Replication Evaluation'
+        )
+        a11y.run_axe(driver, session, 'drftregrepeval')
+
+    def test_accessibility_registering_replication_attempt_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Registering the Replication Attempt Page which is the second page on a
+        Replication Recipe (Brandt et al., 2013): Post-Completion template.  Since
+        the user also has other types of draft registrations, we must search through
+        the cards on the Drafts tab of the My Registrations page and find the card
+        for a Replication Recipe (Brandt et al., 2013): Post-Completion draft and
+        then capture it's draft id so that we can use it to navigate to it's
+        Registering the Replication Attempt page.
+        """
+        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Post-Completion that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Replication Recipe (Brandt et al., 2013): Post-Completion'
+        )
+        registering_replication_page = DraftRegistrationGenericPage(
+            driver,
+            draft_id=draft_id,
+            url_addition='1-registering-the-replication-attempt',
+        )
+        registering_replication_page.goto()
+        assert (
+            registering_replication_page.page_heading.text
+            == 'Registering the Replication Attempt'
+        )
+        a11y.run_axe(driver, session, 'drftregrepatt')
+
+    def test_accessibility_reporting_replication_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Reporting the Replication Page which is the second page on a Replication Recipe
+        (Brandt et al., 2013): Post-Completion template.  Since the user also has other
+        types of draft registrations, we must search through the cards on the Drafts
+        tab of the My Registrations page and find the card for a Replication Recipe
+        (Brandt et al., 2013): Post-Completion draft and then capture it's draft id
+        so that we can use it to navigate to it's Reporting the Replication page.
+        """
+        # capture the draft id from the first Replication Recipe (Brandt et al., 2013):
+        # Post-Completion that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Replication Recipe (Brandt et al., 2013): Post-Completion'
+        )
+        reporting_replication_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='2-reporting-the-replication',
+        )
+        reporting_replication_page.goto()
+        assert (
+            reporting_replication_page.page_heading.text == 'Reporting the Replication'
+        )
+        a11y.run_axe(driver, session, 'drftregreprep')
+
+    def test_accessibility_data_description_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Data Description Page which is the third page on a Secondary Data
+        Preregistration template.  Since the user also has other types of draft
+        registrations, we must search through the cards on the Drafts tab of the My
+        Registrations page and find the card for a Secondary Data Preregistration
+        draft and then capture it's draft id so that we can use it to navigate to
+        it's Data Description page.
+        """
+        # capture the draft id from the first Secondary Data Preregistration that
+        # is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Secondary Data Preregistration'
+        )
+        data_description_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='2-data-description',
+        )
+        data_description_page.goto()
+        assert data_description_page.page_heading.text == 'Data Description'
+        # wait for file widget to load before calling axe
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-files-list-for]')
+            )
+        )
+        a11y.run_axe(driver, session, 'drftregdatadesc')
+
+    def test_accessibility_knowledge_of_data_page(
+        self, driver, session, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Draft Registration
+        Knowledge of Data Page which is the fifth page on a Secondary Data
+        Preregistration template.  Since the user also has other types of draft
+        registrations, we must search through the cards on the Drafts tab of the My
+        Registrations page and find the card for a Secondary Data Preregistration
+        draft and then capture it's draft id so that we can use it to navigate to
+        it's Knowledge of Data page.
+        """
+        # capture the draft id from the first Secondary Data Preregistration that
+        # is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'Secondary Data Preregistration'
+        )
+        data_knowledge_page = DraftRegistrationGenericPage(
+            driver, draft_id=draft_id, url_addition='4-knowledge-of-data',
+        )
+        data_knowledge_page.goto()
+        assert data_knowledge_page.page_heading.text == 'Knowledge of Data'
+        a11y.run_axe(driver, session, 'drftregknowdata')
+
+    def test_accessibility_review_page(self, driver, session, my_registrations_page):
+        """This test is for checking the accessibility of the Draft Registration Review
+        Page which is the final page of any template.  In this case we are using an OSF
+        Preregistration draft registration since it is one of the longer templates and
+        therefore more data is displayed on the review page.  Since the user also has
+        other types of draft registrations, we must search through the cards on the
+        Drafts tab of the My Registrations page and find the card for an OSF
+        Preregistration and then capture it's draft id so that we can use it to navigate
+        to it's Other page.
+        """
+        # capture the draft id from the first OSF Preregistration that is listed
+        draft_id = my_registrations_page.get_first_draft_id_by_template(
+            'OSF Preregistration'
+        )
+        review_page = DraftRegistrationReviewPage(driver, draft_id=draft_id)
+        review_page.goto()
+        assert DraftRegistrationReviewPage(driver, verify=True)
+        a11y.run_axe(driver, session, 'drftregreview')
+
+
+class TestBrandedRegistrationsProviders:
+    """For all the Branded Providers in each environment we are just going to load the
+    discover page since the provider pages should be structured just like the OSF Registries
+    pages which we just tested above. The only real problems that we will be looking for
+    are color contrast issues.
+    """
+
+    def providers():
+        """Return all registration providers.
+        """
+        return osf_api.get_providers_list(type='registrations')
+
+    @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
+    def provider(self, request):
+        return request.param
+
+    def test_accessibility(self, session, driver, provider):
+        discover_page = RegistriesDiscoverPage(driver, provider=provider)
+        discover_page.goto()
+        assert RegistriesDiscoverPage(driver, verify=True)
+        discover_page.loading_indicator.here_then_gone()
+        page_name = 'br_' + provider['id']
+        a11y.run_axe(driver, session, page_name)
+
+
+# we do not currently have a user setup as a moderator for any of the registries in production
+@markers.dont_run_on_prod
+class TestModerationPages:
+    """To test the Moderation pages we must login as a user that has been setup as a
+    moderator for one of the registry providers that has moderation enabled.  We are
+    using the egap registry since it exists in all testing environments and has the
+    moderation process enabled in each environment.
+    """
+
+    @pytest.fixture
+    def provider(self, driver):
+        return osf_api.get_provider(provider_id='egap')
+
+    def test_accessibility_moderation_submissions(
+        self, driver, session, provider, must_be_logged_in
+    ):
+        submissions_page = RegistriesModerationSubmissionsPage(
+            driver, provider=provider
+        )
+        submissions_page.goto()
+        assert RegistriesModerationSubmissionsPage(driver, verify=True)
+        # wait for registration table to load before calling axe
+        if submissions_page.no_registrations_message.absent():
+            WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-registration-list-card]')
+                )
+            )
+        a11y.run_axe(driver, session, 'regmodsub')
+
+    def test_accessibility_moderation_moderators(
+        self, driver, session, provider, must_be_logged_in
+    ):
+        moderators_page = RegistriesModerationModeratorsPage(driver, provider=provider)
+        moderators_page.goto()
+        assert RegistriesModerationModeratorsPage(driver, verify=True)
+        # wait for moderators table to load before calling axe
+        WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-moderator-row]')
+            )
+        )
+        a11y.run_axe(driver, session, 'regmodmod')
+
+    def test_accessibility_moderation_notifications(
+        self, driver, session, provider, must_be_logged_in
+    ):
+        notifications_page = RegistriesModerationNotificationsPage(
+            driver, provider=provider
+        )
+        notifications_page.goto()
+        assert RegistriesModerationNotificationsPage(driver, verify=True)
+        # wait for notifications list to load before calling axe
+        WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-subscription-list-row]')
+            )
+        )
+        a11y.run_axe(driver, session, 'regmodnot')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To create a new test that performs accessibility checks on all of the pages in the OSF Registries product area.


## Summary of Changes

- pages/registrations.py - new page file with definitions for MyRegistrationsPage
- pages/registries.py - updates to BaseRegistriesPage and to existing page classes that inherit from this base class; addition of new page classes: RegistriesModerationSubmissionsPage, RegistriesModerationModeratorsPage, RegistriesModerationSettingsPage, BaseRegistrationDraftPage, DraftRegistrationMetadataPage, DraftRegistrationGenericPage, and DraftRegistrationReviewPage.
- tests/test_a11y_registries.py - new test that loads each of the pages associated with the OSF Registries product area and then performs accessibility checks on each page. Registries pages include: Registries Landing Page, Registries Discover Page, Submitted Registration Detail Page, My Registrations Page, Add New Registration Page, Draft Registration Pages for various templates/schemas supported by OSF, Discover Page for any Branded Registry Providers in each environment, Registries Moderation Submission Page, Registries Moderation Moderators Page, and Registries Moderation Settings Page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/newTest/registries`

Run this test using
`tests/test_a11y_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2988: SEL: Accessibility - Create Registries Test
https://openscience.atlassian.net/browse/ENG-2988
