### PR TITLE
[ENG-3311] - Adding a11y tests of Preprint Reviews pages

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -168,3 +168,72 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     view_page = Locator(By.ID, 'view-page')
     authors_load_indicator = Locator(By.CSS_SELECTOR, '.comma-list > .ball-pulse')
+
+
+class ReviewsDashboardPage(OSFBasePage):
+    url = settings.OSF_HOME + '/reviews'
+    identity = Locator(By.CLASS_NAME, '_reviews-dashboard-header_jdu5ey')
+
+
+class BaseReviewsPage(OSFBasePage):
+    """The base page from which all preprint provider review pages inherit.
+    """
+
+    base_url = settings.OSF_HOME + '/reviews/preprints/'
+    url_addition = ''
+    navbar = ComponentLocator(PreprintsNavbar)
+    title = Locator(By.CLASS_NAME, '_provider-title_hcnzoe')
+
+    def __init__(self, driver, verify=False, provider=None):
+        self.provider = provider
+        if provider:
+            self.provider_id = provider['id']
+            self.provider_name = provider['attributes']['name']
+
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        """Set the URL based on the provider domain.
+        """
+        return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
+
+    def verify(self):
+        """Return true if you are on the expected page.
+        Checks both the general page identity and the branding.
+        """
+        if self.provider:
+            return super().verify() and self.provider_name in self.title.text
+        return super().verify()
+
+
+class ReviewsSubmissionsPage(BaseReviewsPage):
+    identity = Locator(By.CLASS_NAME, '_reviews-list-heading_k45x8p')
+    no_submissions = Locator(
+        By.CSS_SELECTOR,
+        'div._reviews-list-body_k45x8p > div.text-center.p-v-md._moderation-list-row_xkm0pa',
+    )
+
+
+class ReviewsWithdrawalsPage(BaseReviewsPage):
+    url_addition = 'withdrawals'
+    identity = Locator(By.CLASS_NAME, '_reviews-list-heading_k45x8p')
+    no_requests = Locator(
+        By.CSS_SELECTOR,
+        'div._reviews-list-body_k45x8p > div.text-center.p-v-md._moderation-list-row_xkm0pa',
+    )
+
+
+class ReviewsModeratorsPage(BaseReviewsPage):
+    url_addition = 'moderators'
+    identity = Locator(By.CLASS_NAME, 'moderator-list-row')
+
+
+class ReviewsNotificationsPage(BaseReviewsPage):
+    url_addition = 'notifications'
+    identity = Locator(By.CLASS_NAME, '_notification-list-heading-container_kchmy0')
+
+
+class ReviewsSettingsPage(BaseReviewsPage):
+    url_addition = 'settings'
+    identity = Locator(By.CLASS_NAME, '_reviews-settings_1r3x0j')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the coverage of the Preprints Accessibility tests to include the Preprint Reviews pages.


## Summary of Changes

- pages/preprints.py - addition of 7 new page definition classes: ReviewsDashboardPage, BaseReviewsPage, ReviewsSubmissionsPage, ReviewsWithdrawalsPage, ReviewsModeratorsPage, ReviewsNotificationsPage, and ReviewsSettingsPage.
- tests/test_a11y_preprints.py - addition of accessibility tests for the 6 Preprint Reviews pages which include: Preprint Reviews Dashboard, Provider Specific Reviews Submissions Page, Provider Specific Reviews Withdrawals Page, Provider Specific Reviews Moderators Page, Provider Specific Reviews Notifications Page, and Provider Specific Reviews Settings Page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints`

Run this test using
`tests/test_a11y_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3311: SEL: A11y - Preprints Test - Add Reviews Pages
https://openscience.atlassian.net/browse/ENG-3311
