### PR TITLE
[ENG-3341] - Update Preprint Detail Page test to work in all environments

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -155,6 +155,11 @@ class PreprintDiscoverPage(BasePreprintPage):
 
     identity = Locator(By.ID, 'share-logo')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    search_box = Locator(By.ID, 'searchBox')
+    sort_button = Locator(By.ID, 'sortBy')
+    sort_option_newest_to_oldest = Locator(
+        By.CSS_SELECTOR, '#sortByOptionList > li:nth-child(3) > button'
+    )
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '.search-result h4 > a')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the Preprints a11y test to be able to test the Preprints Detail page in all testing environments.

## Summary of Changes
NOTE: This is an application of changes made to tests/test_preprints.py in the osf-selenium-tests repository in PR #168 (https://github.com/CenterForOpenScience/osf-selenium-tests/pull/168)

- pages/preprints.py - adding necessary elements to the Preprints Discover page class.
- tests/test_preprints.py - updating TestPreprintDetailPage to use the Share searching functionality to search Preprints by the "identifiers" metadata field. Entering "identifiers:" + environment url in the search input box ensures that the search results in each test environment are only for that environment. This is necessary since the Share testing server is shared between all testing environments. 


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints`

Run this test using
`tests/test_a11y_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3341: SEL: A11y - Preprints Test - Update Preprint Detail Page Test to work in all environments
https://openscience.atlassian.net/browse/ENG-3341
