### PR TITLE
[ENG-3369] - Setup GitHub Actions for Accessibility Test Suite

### DIFF
--- a/.github/workflows/preprints_a11y_tests.yml
+++ b/.github/workflows/preprints_a11y_tests.yml
@@ -1,0 +1,107 @@
+name: Preprints A11y Tests
+
+on:
+  workflow_call:
+    inputs:
+      domain:
+        description: 'Testing Envrionment'
+        required: true
+        default: 'stage1'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Testing Envrionment'
+        required: true
+        default: 'stage1'
+
+env:
+  DRIVER: "Remote"
+  DOMAIN: ${{ github.event.inputs.domain }}
+  NEW_USER_EMAIL: ${{ secrets.NEW_USER_EMAIL }}
+  BSTACK_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BSTACK_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  CHROME_USER: ${{ secrets.CHROME_USER }}
+  CHROME_USER_TOKEN: ${{ secrets.CHROME_USER_TOKEN }}
+  EDGE_USER: ${{ secrets.EDGE_USER }}
+  EDGE_USER_TOKEN: ${{ secrets.EDGE_USER_TOKEN }}
+  FIREFOX_USER: ${{ secrets.FIREFOX_USER }}
+  FIREFOX_USER_TOKEN: ${{ secrets.FIREFOX_USER_TOKEN }}
+  USER_ONE: ${{ secrets.USER_ONE }}
+  USER_ONE_PASSWORD: ${{ secrets.USER_ONE_PASSWORD }}
+  USER_TWO: ${{ secrets.USER_TWO }}
+  USER_TWO_PASSWORD: ${{ secrets.USER_TWO_PASSWORD }}
+  DEACTIVATED_USER: ${{ secrets.DEACTIVATED_USER }}
+  DEACTIVATED_USER_PASSWORD: ${{ secrets.DEACTIVATED_USER_PASSWORD }}
+  UNCONFIRMED_USER: ${{ secrets.UNCONFIRMED_USER }}
+  UNCONFIRMED_USER_PASSWORD: ${{ secrets.UNCONFIRMED_USER_PASSWORD }}
+  CAS_2FA_USER: ${{ secrets.CAS_2FA_USER }}
+  CAS_2FA_USER_PASSWORD: ${{ secrets.CAS_2FA_USER_PASSWORD }}
+  CAS_TOS_USER: ${{ secrets.CAS_TOS_USER }}
+  CAS_TOS_USER_PASSWORD: ${{ secrets.CAS_TOS_USER_PASSWORD }}
+  DEVAPP_CLIENT_ID: ${{ secrets.DEVAPP_CLIENT_ID }}
+  DEVAPP_CLIENT_SECRET: ${{ secrets.DEVAPP_CLIENT_SECRET }}
+  IMAP_EMAIL: ${{ secrets.IMAP_EMAIL }}
+  IMAP_EMAIL_PASSWORD: ${{ secrets.IMAP_EMAIL_PASSWORD }}
+  IMAP_HOST: ${{ secrets.IMAP_HOST }}
+  A11Y_REGISTRATIONS_USER: ${{ secrets.A11Y_REGISTRATIONS_USER }}
+  A11Y_REGISTRATIONS_PASSWORD: ${{ secrets.A11Y_REGISTRATIONS_PASSWORD }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        python-version: [3.6]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache Build Requirements
+        id: pip-cache-step
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: install dependencies
+        if: steps.pip-cache-step.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          invoke requirements
+
+  staging_test:
+    name: Staging tests (${{ matrix.browser }})
+    needs: build
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1  # run in series
+      matrix:
+        browser: [chrome, firefox, edge]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: run staging tests
+        env:
+          TEST_BUILD: ${{ matrix.browser }}
+        run: |
+          invoke test_preprints_accessibility

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Invoke tasks. To run a task, run ``$ invoke <COMMAND>``. To see a list of
+commands, run ``$ invoke --list``.
+"""
+
+import glob
+import logging
+import os
+import sys
+
+from invoke import task
+
+logging.getLogger('invoke').setLevel(logging.CRITICAL)
+
+HERE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+BIN_PATH = os.path.dirname(sys.executable)
+bin_prefix = lambda cmd: os.path.join(BIN_PATH, cmd)
+MAX_RETRIES = int(os.getenv('MAX_RETRIES', 0))
+
+
+@task(aliases=['flake8'])
+def flake(ctx):
+    ctx.run('flake8 .', echo=True)
+
+
+@task(aliases=['autopep8'])
+def autopep(ctx):
+    ctx.run('autopep8 .', echo=True)
+
+
+@task
+def clean(ctx, verbose=False):
+    ctx.run('find . -name "*.pyc" -delete', echo=True)
+
+
+@task(aliases=['req'])
+def requirements(ctx, dev=False):
+    """Install python dependencies.
+
+    Examples:
+        invoke requirements
+    """
+
+    req_file = os.path.join(HERE, 'requirements.txt')
+    cmd = bin_prefix('pip install --exists-action w --upgrade -r {} '.format(req_file))
+    ctx.run(cmd, echo=True)
+
+
+@task
+def test_module_wo_exit(ctx, module=None, params=None):
+    """Helper for running tests."""
+    import pytest
+
+    if params is None:
+        params = []
+
+    args = ['-s', '-v', '--tb=short', '--write_files', 'false', '--exclude_best_practice', 'true']
+    for e in [module, params]:
+        if e:
+            args.extend([e] if isinstance(e, str) else e)
+
+    print('>>> pytest args: {}'.format(args))
+    retcode = pytest.main(args)
+    return retcode
+
+
+@task
+def test_module(ctx, module=None, params=None):
+    """Helper for running tests."""
+    retcode = test_module_wo_exit(ctx, module, params)
+    sys.exit(retcode)
+
+
+@task
+def test_ember_accessibility(ctx):
+    """Run the accessibility test for Ember pages on the browser defined by TEST_BUILD.
+    This task will be invoked after 'ember-osf-web' has been deployed to any testing
+    environment.   In order to be included in this test run the test must have the
+    pytest marker 'ember_page'.
+    """
+    test_with_retries(
+        ctx, 'Ember Pages', _get_test_file_list(), module=['-m', 'ember_page']
+    )
+
+
+@task
+def test_preprints_accessibility(ctx):
+    """Run the accessibility test for Preprints on the browser defined by TEST_BUILD.
+    This task will be invoked after 'ember-osf-preprints' has been deployed to any
+    testing environment.
+    """
+    file_list = ['tests/test_a11y_preprints.py']
+    test_with_retries(ctx, 'Preprints', file_list)
+
+
+def _get_test_file_list():
+    all_test_files = glob.glob('tests/test_*.py')
+    all_test_files.sort()
+    return all_test_files
+
+
+@task
+def test_with_retries(ctx, partition_name, file_list, module=None):
+    """Run group of tests on the browser defined by TEST_BUILD."""
+    flake(ctx)
+
+    print(
+        '>>> Testing {} modules in "/tests/" in {}'.format(
+            partition_name, os.environ['TEST_BUILD']
+        )
+    )
+    print('>>> File list for {} is: {}'.format(partition_name, file_list))
+    retcode = test_module_wo_exit(ctx, params=file_list, module=module)
+
+    if retcode != 1:
+        sys.exit(retcode)
+
+    file_list = ['--last-failed', '--last-failed-no-failures', 'none'] + file_list
+
+    for i in range(1, MAX_RETRIES + 1):
+        print(
+            '>>> Retesting {} failures, iteration {}, in "/test/" '
+            'in {}'.format(partition_name, i, os.environ['TEST_BUILD'])
+        )
+        retcode = test_module_wo_exit(ctx, params=file_list, module=module)
+
+        if retcode != 1:
+            break
+
+    sys.exit(retcode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from distutils.util import strtobool
+
 import pytest
 from faker import Faker
 from pythosf import client
@@ -110,3 +112,48 @@ def project_with_file(session, default_project):
     else:
         osf_api.upload_fake_file(session, default_project)
     return default_project
+
+
+def pytest_addoption(parser):
+    """Accept input parameters when running pytest from command line
+    """
+    # Flag to determine whether to write accessibility output files
+    parser.addoption('--write_files', action='store')
+    # Flag to determine whether to exclude Best Practice rules from accessibility check
+    parser.addoption('--exclude_best_practice', action='store')
+
+
+@pytest.fixture()
+def write_files(pytestconfig):
+    """Fixture to use command line input to turn on or off the writing of output files
+    from the accessibility checks.  Default (True) is to write the output files.  To
+    use this when running pytest from command line add '--write_files <value>' to the
+    end of the arguments for pytest.
+    EX: 'pytest tests/test_a11y_preprints.py -s -v --write_files false'
+    Valid input values (regardless of capitalization) are:
+        True values are 'y', 'yes', 't', 'true', 'on', and '1'
+        False values are 'n', 'no', 'f', 'false', 'off', and '0'
+        Raises ValueError if input value is anything else.
+    """
+    if pytestconfig.getoption('write_files') is None:
+        return True
+    else:
+        return strtobool(pytestconfig.getoption('write_files'))
+
+
+@pytest.fixture()
+def exclude_best_practice(pytestconfig):
+    """Fixture to use command line input to exclude the Best Practice rule set from the
+    accessibility checks.  Default (False) is to include the Best Practice rules. To use
+    this when running pytest from command line add '--exclude_best_practice <value>' to
+    the end of the arguments for pytest.
+    EX: 'pytest tests/test_a11y_preprints.py -s -v --exclude_best_practice true'
+    Valid input values (regardless of capitalization) are:
+        True values are 'y', 'yes', 't', 'true', 'on', and '1'
+        False values are 'n', 'no', 'f', 'false', 'off', and '0'
+        Raises ValueError if input value is anything else.
+    """
+    if pytestconfig.getoption('exclude_best_practice') is None:
+        return False
+    else:
+        return strtobool(pytestconfig.getoption('exclude_best_practice'))

--- a/tests/test_a11y_preprints.py
+++ b/tests/test_a11y_preprints.py
@@ -24,29 +24,49 @@ from pages.preprints import (
 
 
 class TestPreprintLandingPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         landing_page = PreprintLandingPage(driver)
         landing_page.goto()
         assert PreprintLandingPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'preprints')
+        a11y.run_axe(
+            driver,
+            session,
+            'preprints',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestPreprintSubmitPage:
     @pytest.mark.skipif(
         not settings.PRODUCTION, reason='This version is only for Production'
     )
-    def test_accessibility_prod(self, driver, session, must_be_logged_in):
+    def test_accessibility_prod(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         """This is a lite version of the Preprint Submit page test just for Production.
         It just navigates to the Submit page without attempting to start a new Preprint.
         """
         submit_page = PreprintSubmitPage(driver)
         submit_page.goto()
         assert PreprintSubmitPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prepsub')
+        a11y.run_axe(
+            driver,
+            session,
+            'prepsub',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     @markers.dont_run_on_prod
     def test_accessibility_non_prod(
-        self, driver, session, project_with_file, must_be_logged_in
+        self,
+        driver,
+        session,
+        project_with_file,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         """This version of the Preprint Submit page test will run on any of the testing
         environments since it creates a fake project with file attached from which a new
@@ -76,11 +96,17 @@ class TestPreprintSubmitPage:
         submit_page.preregistration_input.send_keys_deliberately('QA Testing')
         submit_page.save_author_assertions.click()
         submit_page.basics_abstract_input.click()
-        a11y.run_axe(driver, session, 'prepsub')
+        a11y.run_axe(
+            driver,
+            session,
+            'prepsub',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestPreprintDiscoverPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         # The previous test (Submit page - non prod) may trigger a pop-up alert
         #     messagebox that leaving the page will cause data to not be saved.  At
         #     this point this seems to only be happening with Chrome.  If we get
@@ -95,11 +121,17 @@ class TestPreprintDiscoverPage:
         discover_page.goto()
         assert PreprintDiscoverPage(driver, verify=True)
         discover_page.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'prepdisc')
+        a11y.run_axe(
+            driver,
+            session,
+            'prepdisc',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestPreprintDetailPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         discover_page = PreprintDiscoverPage(driver)
         discover_page.goto()
         assert PreprintDiscoverPage(driver, verify=True)
@@ -124,7 +156,13 @@ class TestPreprintDetailPage:
         detail_page = PreprintDetailPage(driver, verify=True)
         # wait for authors list to fully load so that it doesn't trigger list violation
         detail_page.authors_load_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'prepdet')
+        a11y.run_axe(
+            driver,
+            session,
+            'prepdet',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestBrandedProviders:
@@ -143,12 +181,20 @@ class TestBrandedProviders:
     def provider(self, request):
         return request.param
 
-    def test_accessibility(self, session, driver, provider):
+    def test_accessibility(
+        self, session, driver, provider, write_files, exclude_best_practice
+    ):
         landing_page = PreprintLandingPage(driver, provider=provider)
         landing_page.goto()
         assert PreprintLandingPage(driver, verify=True)
         page_name = 'bp_' + provider['id']
-        a11y.run_axe(driver, session, page_name)
+        a11y.run_axe(
+            driver,
+            session,
+            page_name,
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 # We do not currently have a user setup as an administrator or noderator for any of the
@@ -160,7 +206,9 @@ class TestPreprintReviewsDashboardPage:
     that has moderation enabled.
     """
 
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         dashboard_page = ReviewsDashboardPage(driver)
         dashboard_page.goto()
         assert ReviewsDashboardPage(driver, verify=True)
@@ -168,7 +216,13 @@ class TestPreprintReviewsDashboardPage:
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, 'div._action-body_zlyyw2'))
         )
-        a11y.run_axe(driver, session, 'revdash')
+        a11y.run_axe(
+            driver,
+            session,
+            'revdash',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 # We do not currently have a user setup as an administrator or noderator for any of the
@@ -187,7 +241,13 @@ class TestProviderReviewsPages:
         return osf_api.get_provider(type='preprints', provider_id='marxiv')
 
     def test_accessibility_reviews_submissions(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         submissions_page = ReviewsSubmissionsPage(driver, provider=provider)
         submissions_page.goto()
@@ -199,10 +259,22 @@ class TestProviderReviewsPages:
                     (By.CLASS_NAME, '_submission-info_xkm0pa')
                 )
             )
-        a11y.run_axe(driver, session, 'revsub')
+        a11y.run_axe(
+            driver,
+            session,
+            'revsub',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_reviews_withdrawals(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         withdrawals_page = ReviewsWithdrawalsPage(driver, provider=provider)
         withdrawals_page.goto()
@@ -214,10 +286,22 @@ class TestProviderReviewsPages:
                     (By.CLASS_NAME, '_submission-info_17iwzt')
                 )
             )
-        a11y.run_axe(driver, session, 'revwthdrwls')
+        a11y.run_axe(
+            driver,
+            session,
+            'revwthdrwls',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_reviews_moderators(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         moderators_page = ReviewsModeratorsPage(driver, provider=provider)
         moderators_page.goto()
@@ -226,10 +310,22 @@ class TestProviderReviewsPages:
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located((By.CLASS_NAME, '_moderator-name_f83dob'))
         )
-        a11y.run_axe(driver, session, 'revmod')
+        a11y.run_axe(
+            driver,
+            session,
+            'revmod',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_reviews_notifications(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         notifications_page = ReviewsNotificationsPage(driver, provider=provider)
         notifications_page.goto()
@@ -238,12 +334,30 @@ class TestProviderReviewsPages:
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located((By.CLASS_NAME, 'notification-title'))
         )
-        a11y.run_axe(driver, session, 'revnot')
+        a11y.run_axe(
+            driver,
+            session,
+            'revnot',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_reviews_settings(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         settings_page = ReviewsSettingsPage(driver, provider=provider)
         settings_page.goto()
         assert ReviewsSettingsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'revset')
+        a11y.run_axe(
+            driver,
+            session,
+            'revset',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To setup GitHub Actions in the selenium-a11y repository so that the accessibility test suite can be triggered and run after deployment of code releases to any of the staging environments.


## Summary of Changes

- .github/workflows/preprints_a11y_tests.yml - new YAML file to define the GitHub Actions workflow for running the Preprints accessibility test suite.
- tasks/__init__.py - new __init__ file that defines the various tasks necessary for running the accessibility test suites from GitHub Actions.
- tests/conftest.py - adding fixtures for command line input flags: write_files and exclude_best_practice
- tests/test_a11y_preprints.py - adding write_files and exclude_best_practice flags to each of the preprints accessibility test steps


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/github-actions`

Run this test using
`invoke test_preprints_accessibility`

## Testing Changes Moving Forward
NA


## Ticket
ENG-3369: SEL: Accessibility - Setup GitHub Actions in selenium-a11y repository
https://openscience.atlassian.net/browse/ENG-3369
