### PR TITLE
[ENG-3369] - Setup GitHub Actions for Accessibility Test Suite - Ember Pages

### DIFF
--- a/.github/workflows/ember_a11y_tests.yml
+++ b/.github/workflows/ember_a11y_tests.yml
@@ -1,0 +1,109 @@
+name: Ember A11y Tests
+
+on:
+  repository_dispatch:
+    types: [code_deploy]
+    inputs:
+      domain:
+        description: 'Testing Environment'
+        required: true
+        default: 'stage1'
+        type: string
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Testing Environment'
+        required: true
+        default: 'stage1'
+
+env:
+  DRIVER: "Remote"
+  DOMAIN: ${{ github.event.inputs.domain }}
+  NEW_USER_EMAIL: ${{ secrets.NEW_USER_EMAIL }}
+  BSTACK_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BSTACK_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  CHROME_USER: ${{ secrets.CHROME_USER }}
+  CHROME_USER_TOKEN: ${{ secrets.CHROME_USER_TOKEN }}
+  EDGE_USER: ${{ secrets.EDGE_USER }}
+  EDGE_USER_TOKEN: ${{ secrets.EDGE_USER_TOKEN }}
+  FIREFOX_USER: ${{ secrets.FIREFOX_USER }}
+  FIREFOX_USER_TOKEN: ${{ secrets.FIREFOX_USER_TOKEN }}
+  USER_ONE: ${{ secrets.USER_ONE }}
+  USER_ONE_PASSWORD: ${{ secrets.USER_ONE_PASSWORD }}
+  USER_TWO: ${{ secrets.USER_TWO }}
+  USER_TWO_PASSWORD: ${{ secrets.USER_TWO_PASSWORD }}
+  DEACTIVATED_USER: ${{ secrets.DEACTIVATED_USER }}
+  DEACTIVATED_USER_PASSWORD: ${{ secrets.DEACTIVATED_USER_PASSWORD }}
+  UNCONFIRMED_USER: ${{ secrets.UNCONFIRMED_USER }}
+  UNCONFIRMED_USER_PASSWORD: ${{ secrets.UNCONFIRMED_USER_PASSWORD }}
+  CAS_2FA_USER: ${{ secrets.CAS_2FA_USER }}
+  CAS_2FA_USER_PASSWORD: ${{ secrets.CAS_2FA_USER_PASSWORD }}
+  CAS_TOS_USER: ${{ secrets.CAS_TOS_USER }}
+  CAS_TOS_USER_PASSWORD: ${{ secrets.CAS_TOS_USER_PASSWORD }}
+  DEVAPP_CLIENT_ID: ${{ secrets.DEVAPP_CLIENT_ID }}
+  DEVAPP_CLIENT_SECRET: ${{ secrets.DEVAPP_CLIENT_SECRET }}
+  IMAP_EMAIL: ${{ secrets.IMAP_EMAIL }}
+  IMAP_EMAIL_PASSWORD: ${{ secrets.IMAP_EMAIL_PASSWORD }}
+  IMAP_HOST: ${{ secrets.IMAP_HOST }}
+  A11Y_REGISTRATIONS_USER: ${{ secrets.A11Y_REGISTRATIONS_USER }}
+  A11Y_REGISTRATIONS_PASSWORD: ${{ secrets.A11Y_REGISTRATIONS_PASSWORD }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        python-version: [3.9.2]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache Build Requirements
+        id: pip-cache-step
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: install dependencies
+        if: steps.pip-cache-step.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          invoke requirements
+
+  staging_test:
+    name: Staging tests (${{ matrix.browser }})
+    needs: build
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1  # run in series
+      matrix:
+        browser: [chrome, firefox, edge]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9.2
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.2
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: run staging tests
+        env:
+          TEST_BUILD: ${{ matrix.browser }}
+        run: |
+          invoke test_ember_accessibility

--- a/components/accessibility.py
+++ b/components/accessibility.py
@@ -41,7 +41,14 @@ class ApplyA11yRules:
             # element does not violate the missing form element label rule in more
             # up-to-date versions of axe-core like the browser extension tool.
             results = axe.run(
-                context={'exclude': [['#search'], ['.m-t-md'], ['._StateText_1iudhh']]},
+                context={
+                    'exclude': [
+                        ['#search'],
+                        ['.text-center'],
+                        ['._StateText_1iudhh'],
+                        ['._UpdateText_1u9k9o'],
+                    ]
+                },
                 options={
                     'runOnly': {
                         'type': 'tag',

--- a/components/accessibility.py
+++ b/components/accessibility.py
@@ -33,14 +33,21 @@ class ApplyA11yRules:
         # Run axe accessibility checks.
         if exclude_best_practice:
             # When exclude_best_practice parameter is set to True, then we want to run
-            # axe with only the WCAG rule sets.
+            # axe with only the WCAG rule sets.  Also excluding element with id 'search'
+            # which is a bit of a hack since the python version of axe that we are using
+            # is outdated and is failing on the search input box on the Registry Discover
+            # pages (including all of the branded registry providers) since the search
+            # input box has an explicit label that has hidden style attributes. The
+            # element does not violate the missing form element label rule in more
+            # up-to-date versions of axe-core like the browser extension tool.
             results = axe.run(
+                context={'exclude': [['#search'], ['.m-t-md'], ['._StateText_1iudhh']]},
                 options={
                     'runOnly': {
                         'type': 'tag',
                         'values': ['wcag2a', 'wcag2aa', 'wcag21aa'],
                     }
-                }
+                },
             )
         else:
             # This runs axe with all available rule sets which includes WCAG and Best

--- a/markers.py
+++ b/markers.py
@@ -11,3 +11,5 @@ dont_run_on_preferred_node = pytest.mark.skipif(
     bool(settings.PREFERRED_NODE),
     reason='Test makes breaking changes to preferred node',
 )
+
+ember_page = pytest.mark.ember_page

--- a/markers.py
+++ b/markers.py
@@ -13,3 +13,4 @@ dont_run_on_preferred_node = pytest.mark.skipif(
 )
 
 ember_page = pytest.mark.ember_page
+legacy_page = pytest.mark.legacy_page

--- a/tests/test_a11y_institutions.py
+++ b/tests/test_a11y_institutions.py
@@ -13,12 +13,19 @@ from pages.institutions import (
 )
 
 
+@markers.ember_page
 class TestInstitutionsLandingPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         landing_page = InstitutionsLandingPage(driver)
         landing_page.goto()
         assert InstitutionsLandingPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'institutions')
+        a11y.run_axe(
+            driver,
+            session,
+            'institutions',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestBrandedInstitutionPages:
@@ -35,7 +42,9 @@ class TestBrandedInstitutionPages:
     def institution(self, request):
         return request.param
 
-    def test_accessibility(self, driver, session, institution):
+    def test_accessibility(
+        self, driver, session, institution, write_files, exclude_best_practice
+    ):
         institution_page = InstitutionBrandedPage(driver, institution_id=institution)
         institution_page.goto()
         assert InstitutionBrandedPage(driver, verify=True)
@@ -48,13 +57,22 @@ class TestBrandedInstitutionPages:
                 )
             )
         page_name = 'bi_' + institution
-        a11y.run_axe(driver, session, page_name)
+        a11y.run_axe(
+            driver,
+            session,
+            page_name,
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 # Can't run this is Production since I don't have admin access to any institutions in Production
 @markers.dont_run_on_prod
+@markers.ember_page
 class TestInstitutionAdminDashboardPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         """ Test using the COS admin dahsboard page - user must already be setup as an admin for the
         COS institution in each environment through the OSF admin app.
         """
@@ -62,4 +80,10 @@ class TestInstitutionAdminDashboardPage:
         dashboard_page.goto()
         assert InstitutionAdminDashboardPage(driver, verify=True)
         dashboard_page.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'biadmindash')
+        a11y.run_axe(
+            driver,
+            session,
+            'biadmindash',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )

--- a/tests/test_a11y_institutions.py
+++ b/tests/test_a11y_institutions.py
@@ -28,6 +28,7 @@ class TestInstitutionsLandingPage:
         )
 
 
+@markers.legacy_page
 class TestBrandedInstitutionPages:
     """ Test the Branded Institution Page for each institution in the environment. Use the osf api to get
     the list of institution ids and then load each branded iinstitution page and run the axe test engine.

--- a/tests/test_a11y_meetings.py
+++ b/tests/test_a11y_meetings.py
@@ -2,12 +2,14 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
+import markers
 from components.accessibility import ApplyA11yRules as a11y
 from pages.meetings import MeetingDetailPage, MeetingsPage
 
 
+@markers.ember_page
 class TestMeetingsLandingPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         meetings_page = MeetingsPage(driver)
         meetings_page.goto()
         assert MeetingsPage(driver, verify=True)
@@ -19,11 +21,18 @@ class TestMeetingsLandingPage:
         meetings_page.scroll_into_view(conference_text)
         meetings_page.register_button.click()
         meetings_page.upload_button.click()
-        a11y.run_axe(driver, session, 'meetings')
+        a11y.run_axe(
+            driver,
+            session,
+            'meetings',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestMeetingDetailPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         """To test the Meeting Detail Page, start at the Meetings Landing Page and then
         scroll down to the meetings list table and click the title link for the first
         meeting in the table to open the detail page for that meeting.
@@ -43,4 +52,10 @@ class TestMeetingDetailPage:
                 (By.CSS_SELECTOR, '[data-test-submissions-list-item-title]')
             )
         )
-        a11y.run_axe(driver, session, 'mtngdet')
+        a11y.run_axe(
+            driver,
+            session,
+            'mtngdet',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )

--- a/tests/test_a11y_other_osf.py
+++ b/tests/test_a11y_other_osf.py
@@ -52,6 +52,7 @@ class TestDashboardPage:
         )
 
 
+@markers.legacy_page
 class TestMyProjectsPage:
     def test_accessibility(
         self, driver, session, write_files, exclude_best_practice, must_be_logged_in
@@ -133,6 +134,7 @@ class TestRegisterPage:
         )
 
 
+@markers.legacy_page
 class TestSearchPage:
     def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         search_page = SearchPage(driver)
@@ -167,6 +169,7 @@ class TestSupportPage:
         )
 
 
+@markers.legacy_page
 class TestForgotPasswordPage:
     def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         forgot_password_page = ForgotPasswordPage(driver)
@@ -181,6 +184,7 @@ class TestForgotPasswordPage:
         )
 
 
+@markers.legacy_page
 # For the next test we have only set up test users with IMAP enabled email address in
 #     the testing environments.
 @markers.dont_run_on_prod

--- a/tests/test_a11y_other_osf.py
+++ b/tests/test_a11y_other_osf.py
@@ -20,32 +20,59 @@ from pages.search import SearchPage
 from pages.support import SupportPage
 
 
+@markers.ember_page
 class TestOSFHomePage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         landing_page = LandingPage(driver)
         landing_page.goto()
         assert LandingPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'home')
+        a11y.run_axe(
+            driver,
+            session,
+            'home',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestDashboardPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         dashboard_page = DashboardPage(driver)
         dashboard_page.goto()
         assert DashboardPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'dash')
+        a11y.run_axe(
+            driver,
+            session,
+            'dash',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestMyProjectsPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         my_projects_page = MyProjectsPage(driver)
         my_projects_page.goto()
         assert MyProjectsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'myproj')
+        a11y.run_axe(
+            driver,
+            session,
+            'myproj',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestMyQuickFilesPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         """ The Quick Files Page may or may not have any files listed depending on the
         current user. Users in the testing environment probably will, but the Production
         user may not.
@@ -54,14 +81,23 @@ class TestMyQuickFilesPage:
         quickfiles_page.goto()
         quickfiles_page.loading_indicator.here_then_gone()
         assert QuickfilesPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'quickfiles')
+        a11y.run_axe(
+            driver,
+            session,
+            'quickfiles',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 # For this next test we are uploading a text file to the user's Quick Files page so we
 #     don't want to run this in Production.
 @markers.dont_run_on_prod
 class TestMyQuickFileDetailPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         osf_api.upload_single_quickfile(session)
         quickfiles_page = QuickfilesPage(driver)
         quickfiles_page.goto()
@@ -73,19 +109,32 @@ class TestMyQuickFileDetailPage:
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located((By.ID, 'mfrIframeParent'))
         )
-        a11y.run_axe(driver, session, 'qfiledet')
+        a11y.run_axe(
+            driver,
+            session,
+            'qfiledet',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestRegisterPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         register_page = RegisterPage(driver)
         register_page.goto()
         assert RegisterPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'signup')
+        a11y.run_axe(
+            driver,
+            session,
+            'signup',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestSearchPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         search_page = SearchPage(driver)
         search_page.goto()
         assert SearchPage(driver, verify=True)
@@ -94,30 +143,49 @@ class TestSearchPage:
         search_page.search_bar.send_keys('*')
         search_page.search_bar.send_keys(Keys.ENTER)
         search_page.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'search')
+        a11y.run_axe(
+            driver,
+            session,
+            'search',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestSupportPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         support_page = SupportPage(driver)
         support_page.goto()
         assert SupportPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'support')
+        a11y.run_axe(
+            driver,
+            session,
+            'support',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestForgotPasswordPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         forgot_password_page = ForgotPasswordPage(driver)
         forgot_password_page.goto()
         assert ForgotPasswordPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'frgtpwrd')
+        a11y.run_axe(
+            driver,
+            session,
+            'frgtpwrd',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 # For the next test we have only set up test users with IMAP enabled email address in
 #     the testing environments.
 @markers.dont_run_on_prod
 class TestResetPasswordPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         # First go to Forgot Password page and enter email address and click Reset
         #     Password button
         forgot_password_page = ForgotPasswordPage(driver)
@@ -136,7 +204,9 @@ class TestResetPasswordPage:
             # To prevent an endless loop waiting for the email
             loop_counter += 1
             if loop_counter == 60:
-                raise Exception('No unseen emails. Verify that Reset Password email was sent.')
+                raise Exception(
+                    'No unseen emails. Verify that Reset Password email was sent.'
+                )
                 break
 
         # Only proceed with accessibility check if there is an email
@@ -160,4 +230,10 @@ class TestResetPasswordPage:
             driver.get(settings.OSF_HOME + reset_URL)
             assert ResetPasswordPage(driver, verify=True)
             # Finally run axe to check accessibility
-            a11y.run_axe(driver, session, 'resetpwrd')
+            a11y.run_axe(
+                driver,
+                session,
+                'resetpwrd',
+                write_files=write_files,
+                exclude_best_practice=exclude_best_practice,
+            )

--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -20,6 +20,7 @@ from pages.project import (
 )
 
 
+@markers.legacy_page
 class TestProjectPage:
     def test_accessibility(
         self,
@@ -49,6 +50,7 @@ class TestProjectPage:
         )
 
 
+@markers.legacy_page
 class TestFilesPage:
     def test_accessibility(
         self,
@@ -76,6 +78,7 @@ class TestFilesPage:
         )
 
 
+@markers.legacy_page
 class TestFileViewPage:
     def test_accessibility(
         self,
@@ -124,6 +127,7 @@ class TestFileViewPage:
         )
 
 
+@markers.legacy_page
 class TestWikiPage:
     def test_accessibility(
         self,
@@ -210,6 +214,7 @@ class TestRegistrationsPage:
         )
 
 
+@markers.legacy_page
 class TestContributorsPage:
     def test_accessibility(
         self,
@@ -236,6 +241,7 @@ class TestContributorsPage:
         )
 
 
+@markers.legacy_page
 class TestAddonsPage:
     def test_accessibility(
         self,
@@ -262,6 +268,7 @@ class TestAddonsPage:
         )
 
 
+@markers.legacy_page
 class TestSettingsPage:
     def test_accessibility(
         self,
@@ -328,6 +335,7 @@ class TestForksPage:
         )
 
 
+@markers.legacy_page
 class TestRequestAccessPage:
     def test_accessibility(
         self,

--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -21,7 +21,15 @@ from pages.project import (
 
 
 class TestProjectPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Project Overview page test we are creating a new dummy test project
         and then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
@@ -32,11 +40,25 @@ class TestProjectPage:
         # wait until file widget has fully loaded so that we can ensure that all sections
         # of project page have fully loaded before applying a11y rules
         project_page.file_widget.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'project')
+        a11y.run_axe(
+            driver,
+            session,
+            'project',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestFilesPage:
-    def test_accessibility(self, driver, session, project_with_file, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        project_with_file,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Project Files page test we are creating a new dummy test project and
         then deleting it after we have finished unless we are running in Production, then
         we are using a Preferred Node from the environment settings file.
@@ -45,11 +67,25 @@ class TestFilesPage:
         files_page.goto()
         files_page.loading_indicator.here_then_gone()
         assert FilesPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prjFiles')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjFiles',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestFileViewPage:
-    def test_accessibility(self, driver, session, project_with_file, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        project_with_file,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the File View page test we are creating a new dummy test project and
         then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
@@ -79,11 +115,25 @@ class TestFileViewPage:
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located((By.ID, 'mfrIframe'))
         )
-        a11y.run_axe(driver, session, 'fileView')
+        a11y.run_axe(
+            driver,
+            session,
+            'fileView',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestWikiPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Wiki page test we are creating a new dummy test project and then
         deleting it after we have finished unless we are running in Production, then
         we are using a Preferred Node from the environment settings file.
@@ -91,11 +141,26 @@ class TestWikiPage:
         wiki_page = WikiPage(driver, guid=default_project.id)
         wiki_page.goto()
         assert WikiPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prjWiki')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjWiki',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestAnalyticsPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Analytics page test we are creating a new dummy test project and
         then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
@@ -107,11 +172,26 @@ class TestAnalyticsPage:
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, '.keen-dataviz-stage'))
         )
-        a11y.run_axe(driver, session, 'prjAnlytcs')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjAnlytcs',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestRegistrationsPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Registrations page test we are creating a new dummy test project
         and then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
@@ -121,11 +201,25 @@ class TestRegistrationsPage:
         assert RegistrationsPage(driver, verify=True)
         # wait until Registration cards are loaded if there are any
         registrations_page.first_registration_title.present()
-        a11y.run_axe(driver, session, 'prjReg')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjReg',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestContributorsPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Contributors page test we are creating a new dummy test project
         and then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
@@ -133,11 +227,25 @@ class TestContributorsPage:
         contributors_page = ContributorsPage(driver, guid=default_project.id)
         contributors_page.goto()
         assert ContributorsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prjCntrb')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjCntrb',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestAddonsPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Add-ons page test we are creating a new dummy test project and then
         deleting it after we have finished unless we are running in Production, then we
         are using a Preferred Node from the environment settings file.
@@ -145,11 +253,25 @@ class TestAddonsPage:
         addons_page = AddonsPage(driver, guid=default_project.id)
         addons_page.goto()
         assert AddonsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prjAddons')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjAddons',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestSettingsPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Settings page test we are creating a new dummy test project and
         then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
@@ -158,12 +280,27 @@ class TestSettingsPage:
         settings_page.goto()
         settings_page.email_notifications_loading_indicator.here_then_gone()
         assert SettingsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prjSttngs')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjSttngs',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 @markers.dont_run_on_prod
 class TestForksPage:
-    def test_accessibility(self, driver, session, default_project, must_be_logged_in):
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
         """ For the Forks page test we are creating a new dummy test project and
         then deleting it after we have finished - also deleting the new fork that
         is created
@@ -182,12 +319,24 @@ class TestForksPage:
         # clean-up leftover fork
         fork_guid = forks_page.fork_link.get_attribute('data-test-node-title')
         osf_api.delete_project(session, fork_guid, None)
-        a11y.run_axe(driver, session, 'prjForks')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjForks',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestRequestAccessPage:
     def test_accessibility(
-        self, driver, session, default_project_page, must_be_logged_in_as_user_two
+        self,
+        driver,
+        session,
+        default_project_page,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in_as_user_two,
     ):
         """ For the Request Access page test we are creating a new dummy test project
         and then deleting it after we have finished unless we are running in Production,
@@ -195,4 +344,10 @@ class TestRequestAccessPage:
         """
         default_project_page.goto(expect_redirect_to=RequestAccessPage)
         assert RequestAccessPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'prjReqAcc')
+        a11y.run_axe(
+            driver,
+            session,
+            'prjReqAcc',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -24,34 +24,49 @@ from pages.registries import (
 )
 
 
+@markers.ember_page
 class TestRegistriesLandingPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         landing_page = RegistriesLandingPage(driver)
         landing_page.goto()
         assert RegistriesLandingPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'registries')
+        a11y.run_axe(
+            driver,
+            session,
+            'registries',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestRegistriesDiscoverPage:
     """This test is for the OSF Registries Discover Page. The other Branded Provider
     Registries Discover pages will be tested below.
     """
 
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         discover_page = RegistriesDiscoverPage(driver)
         discover_page.goto()
         assert RegistriesDiscoverPage(driver, verify=True)
         discover_page.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'regdisc')
+        a11y.run_axe(
+            driver,
+            session,
+            'regdisc',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestRegistrationDetailPage:
     """This test is for the Registration Detail Page for a submitted registration. It
     accesses a submitted registration from the search results on the Registries Discover
     page.
     """
 
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         discover_page = RegistriesDiscoverPage(driver)
         discover_page.goto()
         assert RegistriesDiscoverPage(driver, verify=True)
@@ -78,13 +93,20 @@ class TestRegistrationDetailPage:
         target_registration.click()
         detail_page = RegistrationDetailPage(driver, verify=True)
         detail_page.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'regdet')
+        a11y.run_axe(
+            driver,
+            session,
+            'regdet',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 # User with registrations is not setup in production
 @markers.dont_run_on_prod
+@markers.ember_page
 class TestMyRegistrationsPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         safe_login(
             driver,
             user=settings.A11Y_REGISTRATIONS_USER,
@@ -97,15 +119,30 @@ class TestMyRegistrationsPage:
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '[data-test-node-card]'))
         )
-        a11y.run_axe(driver, session, 'myreg')
+        a11y.run_axe(
+            driver,
+            session,
+            'myreg',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestAddNewRegistrationPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         add_new_registration_page = RegistrationAddNewPage(driver)
         add_new_registration_page.goto()
         assert RegistrationAddNewPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'addnewreg')
+        a11y.run_axe(
+            driver,
+            session,
+            'addnewreg',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 @pytest.fixture(scope='class')
@@ -139,7 +176,10 @@ class TestDraftRegistrationPages:
         assert draft_cards
         return my_registrations_page
 
-    def test_accessibility_metadata_page(self, driver, session, my_registrations_page):
+    @markers.ember_page
+    def test_accessibility_metadata_page(
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
+    ):
         """This test is for checking the accessibility of the Draft Registration Metadata
         page.  We can just pick the first draft registration that is listed, since the
         Metadata page is the same for all schemas.
@@ -150,9 +190,18 @@ class TestDraftRegistrationPages:
         metadata_page = DraftRegistrationMetadataPage(driver, draft_id=draft_id)
         metadata_page.goto()
         assert DraftRegistrationMetadataPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'drftregmeta')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregmeta',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
-    def test_accessibility_summary_page(self, driver, session, my_registrations_page):
+    @markers.ember_page
+    def test_accessibility_summary_page(
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
+    ):
         """This test is for checking the accessibility of the Draft Registration Summary
         Page which is typically the second page on an Open-Ended Registration template.
         Since the user also has other types of draft registrations, we must search through
@@ -175,10 +224,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregsum')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregsum',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_study_information_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Study
         Information Page which is the second page on a Qualitative Preregistration template.
@@ -196,10 +251,16 @@ class TestDraftRegistrationPages:
         )
         study_information_page.goto()
         assert study_information_page.page_heading.text == 'Study Information'
-        a11y.run_axe(driver, session, 'drftregstudy')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregstudy',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_data_collection_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Data
         Collection Page which is the fourth page on a Qualitative Preregistration template.
@@ -217,10 +278,16 @@ class TestDraftRegistrationPages:
         )
         data_collection_page.goto()
         assert data_collection_page.page_heading.text == 'Data Collection'
-        a11y.run_axe(driver, session, 'drftregdatacol')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregdatacol',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_miscellaneous_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Miscellaneous Page which is the sixth page on a Qualitative Preregistration
@@ -238,10 +305,16 @@ class TestDraftRegistrationPages:
         )
         miscellaneous_page.goto()
         assert miscellaneous_page.page_heading.text == 'Miscellaneous'
-        a11y.run_axe(driver, session, 'drftregmisc')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregmisc',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_design_plan_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Design
         Plan Page which is the third page on an OSF Preregistration template.  Since the
@@ -265,10 +338,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregdesign')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregdesign',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_sampling_plan_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Sampling
         Plan Page which is the fourth page on an OSF Preregistration template.  Since the
@@ -292,9 +371,17 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregsampling')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregsampling',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
-    def test_accessibility_variables_page(self, driver, session, my_registrations_page):
+    def test_accessibility_variables_page(
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
+    ):
         """This test is for checking the accessibility of the Draft Registration Variables
         Page which is the fifth page on an OSF Preregistration template.  Since the user
         also has other types of draft registrations, we must search through the cards on
@@ -317,10 +404,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregvariables')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregvariables',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_analysis_plan_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Analysis
         Plan Page which is the sixth page on an OSF Preregistration template.  Since the
@@ -344,10 +437,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftreganalysis')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftreganalysis',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_publication_information_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Publication
         Information Page which is the second page on a Registered Report Protocol Preregistration
@@ -368,10 +467,16 @@ class TestDraftRegistrationPages:
         assert (
             publication_information_page.page_heading.text == 'Publication Information'
         )
-        a11y.run_axe(driver, session, 'drftregpubinfo')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregpubinfo',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_manuscript_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration Manuscript
         Page which is the second page on a Registered Report Protocol Preregistration template.
@@ -396,9 +501,17 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregmnscrpt')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregmnscrpt',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
-    def test_accessibility_other_page(self, driver, session, my_registrations_page):
+    def test_accessibility_other_page(
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
+    ):
         """This test is for checking the accessibility of the Draft Registration Other
         Page which is the fourth page on a Registered Report Protocol Preregistration
         template.  Since the user also has other types of draft registrations, we must
@@ -422,10 +535,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregother')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregother',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_prereg_template_aspredicted_org_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Preregistration Template from AsPredicted.org Page which is the second page on
@@ -451,10 +570,16 @@ class TestDraftRegistrationPages:
             prereg_template_page.page_heading.text
             == 'Preregistration Template from AsPredicted.org'
         )
-        a11y.run_axe(driver, session, 'drftregasprdct')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregasprdct',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_osf_standard_predata_collection_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         OSF-Standard Pre-Data Collection Registration Page which is the second page on
@@ -480,10 +605,16 @@ class TestDraftRegistrationPages:
             predata_collection_page.page_heading.text
             == 'OSF-Standard Pre-Data Collection Registration'
         )
-        a11y.run_axe(driver, session, 'drftregpredata')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregpredata',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_hypotheses_essential_elements_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Hypotheses - Essential elements Page which is the second page on a
@@ -506,10 +637,16 @@ class TestDraftRegistrationPages:
         )
         hypotheses_page.goto()
         assert hypotheses_page.page_heading.text == 'A. Hypotheses - Essential elements'
-        a11y.run_axe(driver, session, 'drftreghypotheses')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftreghypotheses',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_recommended_elements_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Recommended elements Page which is the third page on a Pre-Registration in
@@ -535,10 +672,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregrecelems')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregrecelems',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_methods_essential_elements_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Methods - Essential elements Page which is the fourth page on a
@@ -564,10 +707,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregmethods')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregmethods',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_analysis_plan_essential_elements_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Analysis Plan - Essential elements Page which is the sixth page on a
@@ -593,10 +742,16 @@ class TestDraftRegistrationPages:
             analysis_plan_page.page_heading.text
             == 'C. Analysis plan - Essential elements'
         )
-        a11y.run_axe(driver, session, 'drftregaplnelems')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregaplnelems',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_final_questions_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Final questions Page which is the eighth page on a Pre-Registration in
@@ -616,10 +771,16 @@ class TestDraftRegistrationPages:
         )
         final_questions_page.goto()
         assert final_questions_page.page_heading.text == 'Final questions'
-        a11y.run_axe(driver, session, 'drftregfnlqustns')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregfnlqustns',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_nature_of_the_effect_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         The Nature of the Effect Page which is the second page on a Replication
@@ -640,10 +801,16 @@ class TestDraftRegistrationPages:
         )
         nature_effect_page.goto()
         assert nature_effect_page.page_heading.text == 'The Nature of the Effect'
-        a11y.run_axe(driver, session, 'drftregnateff')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregnateff',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_designing_replication_study_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Designing the Replication Study Page which is the third page on a Replication
@@ -664,10 +831,16 @@ class TestDraftRegistrationPages:
         )
         design_study_page.goto()
         assert design_study_page.page_heading.text == 'Designing the Replication Study'
-        a11y.run_axe(driver, session, 'drftregdesrepstdy')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregdesrepstdy',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_documenting_differences_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Documenting Differences between the Original and Replication Study Page which
@@ -694,10 +867,16 @@ class TestDraftRegistrationPages:
             documenting_differences_page.page_heading.text
             == 'Documenting Differences between the Original and Replication Study'
         )
-        a11y.run_axe(driver, session, 'drftregdocdiff')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregdocdiff',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_analysis_replication_evaluation_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Analysis and Replication Evaluation Page which is the fifth page on a
@@ -723,10 +902,16 @@ class TestDraftRegistrationPages:
             analysis_replication_eval_page.page_heading.text
             == 'Analysis and Replication Evaluation'
         )
-        a11y.run_axe(driver, session, 'drftregrepeval')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregrepeval',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_registering_replication_attempt_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Registering the Replication Attempt Page which is the second page on a
@@ -752,10 +937,16 @@ class TestDraftRegistrationPages:
             registering_replication_page.page_heading.text
             == 'Registering the Replication Attempt'
         )
-        a11y.run_axe(driver, session, 'drftregrepatt')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregrepatt',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_reporting_replication_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Reporting the Replication Page which is the second page on a Replication Recipe
@@ -777,10 +968,16 @@ class TestDraftRegistrationPages:
         assert (
             reporting_replication_page.page_heading.text == 'Reporting the Replication'
         )
-        a11y.run_axe(driver, session, 'drftregreprep')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregreprep',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_data_description_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Data Description Page which is the third page on a Secondary Data
@@ -806,10 +1003,16 @@ class TestDraftRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-files-list-for]')
             )
         )
-        a11y.run_axe(driver, session, 'drftregdatadesc')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregdatadesc',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_knowledge_of_data_page(
-        self, driver, session, my_registrations_page
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
     ):
         """This test is for checking the accessibility of the Draft Registration
         Knowledge of Data Page which is the fifth page on a Secondary Data
@@ -829,9 +1032,18 @@ class TestDraftRegistrationPages:
         )
         data_knowledge_page.goto()
         assert data_knowledge_page.page_heading.text == 'Knowledge of Data'
-        a11y.run_axe(driver, session, 'drftregknowdata')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregknowdata',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
-    def test_accessibility_review_page(self, driver, session, my_registrations_page):
+    @markers.ember_page
+    def test_accessibility_review_page(
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
+    ):
         """This test is for checking the accessibility of the Draft Registration Review
         Page which is the final page of any template.  In this case we are using an OSF
         Preregistration draft registration since it is one of the longer templates and
@@ -848,7 +1060,13 @@ class TestDraftRegistrationPages:
         review_page = DraftRegistrationReviewPage(driver, draft_id=draft_id)
         review_page.goto()
         assert DraftRegistrationReviewPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'drftregreview')
+        a11y.run_axe(
+            driver,
+            session,
+            'drftregreview',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestBrandedRegistrationsProviders:
@@ -867,17 +1085,26 @@ class TestBrandedRegistrationsProviders:
     def provider(self, request):
         return request.param
 
-    def test_accessibility(self, session, driver, provider):
+    def test_accessibility(
+        self, session, driver, provider, write_files, exclude_best_practice
+    ):
         discover_page = RegistriesDiscoverPage(driver, provider=provider)
         discover_page.goto()
         assert RegistriesDiscoverPage(driver, verify=True)
         discover_page.loading_indicator.here_then_gone()
         page_name = 'br_' + provider['id']
-        a11y.run_axe(driver, session, page_name)
+        a11y.run_axe(
+            driver,
+            session,
+            page_name,
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 # We do not currently have a user setup as an administrator for any of the registries in production
 @markers.dont_run_on_prod
+@markers.ember_page
 class TestModerationPages:
     """To test the Moderation pages we must login as a user that has been setup as an
     administrator for one of the registry providers that has moderation enabled.  We
@@ -890,7 +1117,13 @@ class TestModerationPages:
         return osf_api.get_provider(provider_id='egap')
 
     def test_accessibility_moderation_submissions(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         submissions_page = RegistriesModerationSubmissionsPage(
             driver, provider=provider
@@ -904,10 +1137,22 @@ class TestModerationPages:
                     (By.CSS_SELECTOR, '[data-test-registration-list-card]')
                 )
             )
-        a11y.run_axe(driver, session, 'regmodsub')
+        a11y.run_axe(
+            driver,
+            session,
+            'regmodsub',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_moderation_moderators(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         moderators_page = RegistriesModerationModeratorsPage(driver, provider=provider)
         moderators_page.goto()
@@ -918,10 +1163,22 @@ class TestModerationPages:
                 (By.CSS_SELECTOR, '[data-test-moderator-row]')
             )
         )
-        a11y.run_axe(driver, session, 'regmodmod')
+        a11y.run_axe(
+            driver,
+            session,
+            'regmodmod',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_moderation_settings(
-        self, driver, session, provider, must_be_logged_in
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
     ):
         settings_page = RegistriesModerationSettingsPage(driver, provider=provider)
         settings_page.goto()
@@ -932,4 +1189,10 @@ class TestModerationPages:
                 (By.CSS_SELECTOR, '[data-test-subscription-list-row]')
             )
         )
-        a11y.run_axe(driver, session, 'regmodset')
+        a11y.run_axe(
+            driver,
+            session,
+            'regmodset',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )

--- a/tests/test_a11y_user.py
+++ b/tests/test_a11y_user.py
@@ -15,6 +15,7 @@ from pages.user import (
 )
 
 
+@markers.legacy_page
 class TestUserProfilePage:
     def test_accessibility(
         self, driver, session, write_files, exclude_best_practice, must_be_logged_in
@@ -31,6 +32,7 @@ class TestUserProfilePage:
         )
 
 
+@markers.legacy_page
 class TestUserSettingsProfileInformationPage:
     @pytest.fixture()
     def profile_information_page(self, driver, must_be_logged_in):
@@ -153,6 +155,7 @@ class TestUserSettingsAccountSettingsPage:
         )
 
 
+@markers.legacy_page
 class TestUserSettingsConfigureAddonsPage:
     def test_accessibility(
         self, driver, session, write_files, exclude_best_practice, must_be_logged_in
@@ -169,6 +172,7 @@ class TestUserSettingsConfigureAddonsPage:
         )
 
 
+@markers.legacy_page
 class TestUserSettingsNotificationsPage:
     def test_accessibility(
         self, driver, session, write_files, exclude_best_practice, must_be_logged_in

--- a/tests/test_a11y_user.py
+++ b/tests/test_a11y_user.py
@@ -1,5 +1,6 @@
 import pytest
 
+import markers
 from components.accessibility import ApplyA11yRules as a11y
 from pages.user import (
     AccountSettingsPage,
@@ -15,11 +16,19 @@ from pages.user import (
 
 
 class TestUserProfilePage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         profile_page = UserProfilePage(driver)
         profile_page.goto()
         assert UserProfilePage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrProf')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrProf',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestUserSettingsProfileInformationPage:
@@ -29,13 +38,33 @@ class TestUserSettingsProfileInformationPage:
         profile_information_page.goto()
         return profile_information_page
 
-    def test_accessibility_name_tab(self, driver, session, profile_information_page):
+    def test_accessibility_name_tab(
+        self,
+        driver,
+        session,
+        write_files,
+        exclude_best_practice,
+        profile_information_page,
+    ):
         """ Test Name Tab (default) of User Settings Profile Information Page
         """
         assert ProfileInformationPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetPrfName')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetPrfName',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
-    def test_accessibility_social_tab(self, driver, session, profile_information_page):
+    def test_accessibility_social_tab(
+        self,
+        driver,
+        session,
+        write_files,
+        exclude_best_practice,
+        profile_information_page,
+    ):
         """ Test Social Tab of User Settings Profile Information Page
         """
         # Running Axe in the previous step leaves you at the bottom of the page, so we
@@ -46,10 +75,21 @@ class TestUserSettingsProfileInformationPage:
         )
         profile_information_page.social_tab_link.click()
         assert ProfileInformationPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetPrfSoc')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetPrfSoc',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_employment_tab(
-        self, driver, session, profile_information_page
+        self,
+        driver,
+        session,
+        write_files,
+        exclude_best_practice,
+        profile_information_page,
     ):
         """ Test Employment Tab of User Settings Profile Information Page
         """
@@ -61,10 +101,21 @@ class TestUserSettingsProfileInformationPage:
         )
         profile_information_page.employment_tab_link.click()
         assert ProfileInformationPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetPrfEmp')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetPrfEmp',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
     def test_accessibility_education_tab(
-        self, driver, session, profile_information_page
+        self,
+        driver,
+        session,
+        write_files,
+        exclude_best_practice,
+        profile_information_page,
     ):
         """ Test Education Tab of User Settings Profile Information Page
         """
@@ -76,62 +127,129 @@ class TestUserSettingsProfileInformationPage:
         )
         profile_information_page.education_tab_link.click()
         assert ProfileInformationPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetPrfEd')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetPrfEd',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestUserSettingsAccountSettingsPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         account_settings_page = AccountSettingsPage(driver)
         account_settings_page.goto()
         assert AccountSettingsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetAccnt')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetAccnt',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestUserSettingsConfigureAddonsPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         configure_addons_page = ConfigureAddonsPage(driver)
         configure_addons_page.goto()
         assert ConfigureAddonsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetAddons')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetAddons',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestUserSettingsNotificationsPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         notifications_page = NotificationsPage(driver)
         notifications_page.goto()
         assert NotificationsPage(driver, verify=True)
         # wait for Notification Preferences section to finish loading
         notifications_page.loading_indicator.here_then_gone()
-        a11y.run_axe(driver, session, 'usrSetNtfctns')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetNtfctns',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestUserSettingsDeveloperAppsPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         developer_apps_page = EmberDeveloperAppsPage(driver)
         developer_apps_page.goto()
         assert EmberDeveloperAppsPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetDevApp')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetDevApp',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestUserSettingsCreateDeveloperAppPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         create_dev_app_page = CreateDeveloperAppPage(driver)
         create_dev_app_page.goto()
         assert CreateDeveloperAppPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetCrtDevApp')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetCrtDevApp',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestUserSettingsPersonalAccessTokensPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         personal_access_tokens_page = EmberPersonalAccessTokenPage(driver)
         personal_access_tokens_page.goto()
         assert EmberPersonalAccessTokenPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetPAT')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetPAT',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
+@markers.ember_page
 class TestUserSettingsCreatePersonalAccessTokenPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         create_personal_access_tokens_page = CreatePersonalAccessTokenPage(driver)
         create_personal_access_tokens_page.goto()
         assert CreatePersonalAccessTokenPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'usrSetCrtPAT')
+        a11y.run_axe(
+            driver,
+            session,
+            'usrSetCrtPAT',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )

--- a/utils.py
+++ b/utils.py
@@ -55,6 +55,7 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         from selenium.webdriver.chrome.options import Options
 
         chrome_options = Options()
+        chrome_options.set_capability('unhandledPromptBehavior', 'accept')
         # disable w3c for local testing
         chrome_options.add_experimental_option('w3c', False)
         preferences = {'download.default_directory': ''}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To setup a GitHub Action in the selenium-a11y repository so that the accessibility tests for Ember pages can be triggered and run after deployment of code releases to any of the staging environments.

## Summary of Changes

- .github/workflows/ember_a11y_tests.yml - new YAML file to define the GitHub Actions workflow for running the accessibility tests that are specific to Ember pages.
- markers.py - adding "ember_page" and "legacy_page" markers to be used to mark tests within the different accessibility testing files.
- adding "ember_page" and "legacy_page" markers to specific test steps in the following test files:
       - test_a11y_collections.py
       - test_a11y_institutions.py
       - test_a11y_meetings.py
      - test_a11y_other_osf.py
      - test_a11y_project.py
      - test_a11y_registries.py
      - test_a11y_user.py


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/feature/github-actions`

Run this test using
invoke test_ember_accessibility

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3369 - SEL: Accessibility - Setup GitHub Actions in selenium-a11y repository
https://openscience.atlassian.net/browse/ENG-3369
