### PR TITLE
[ENG-3427] - Update Registries Test for Outcome Reporting Project

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -86,8 +86,16 @@ class RegistrationAddNewPage(BaseRegistriesPage):
         return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
 
 
-class RegistriesModerationSubmissionsPage(BaseRegistriesPage):
-    url_addition = 'moderation/submissions'
+class RegistriesModerationSubmittedPage(BaseRegistriesPage):
+    url_addition = 'moderation/submitted'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type]')
+    no_registrations_message = Locator(
+        By.CSS_SELECTOR, '[data-test-registration-list-none]'
+    )
+
+
+class RegistriesModerationPendingPage(BaseRegistriesPage):
+    url_addition = 'moderation/pending'
     identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type]')
     no_registrations_message = Locator(
         By.CSS_SELECTOR, '[data-test-registration-list-none]'

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -19,8 +19,9 @@ from pages.registries import (
     RegistriesDiscoverPage,
     RegistriesLandingPage,
     RegistriesModerationModeratorsPage,
+    RegistriesModerationPendingPage,
     RegistriesModerationSettingsPage,
-    RegistriesModerationSubmissionsPage,
+    RegistriesModerationSubmittedPage,
 )
 
 
@@ -1116,7 +1117,7 @@ class TestModerationPages:
     def provider(self, driver):
         return osf_api.get_provider(provider_id='egap')
 
-    def test_accessibility_moderation_submissions(
+    def test_accessibility_moderation_submitted(
         self,
         driver,
         session,
@@ -1125,13 +1126,11 @@ class TestModerationPages:
         exclude_best_practice,
         must_be_logged_in,
     ):
-        submissions_page = RegistriesModerationSubmissionsPage(
-            driver, provider=provider
-        )
-        submissions_page.goto()
-        assert RegistriesModerationSubmissionsPage(driver, verify=True)
+        submitted_page = RegistriesModerationSubmittedPage(driver, provider=provider)
+        submitted_page.goto()
+        assert RegistriesModerationSubmittedPage(driver, verify=True)
         # Wait for registration table to load before calling axe
-        if submissions_page.no_registrations_message.absent():
+        if submitted_page.no_registrations_message.absent():
             WebDriverWait(driver, 5).until(
                 EC.presence_of_element_located(
                     (By.CSS_SELECTOR, '[data-test-registration-list-card]')
@@ -1141,6 +1140,33 @@ class TestModerationPages:
             driver,
             session,
             'regmodsub',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
+
+    def test_accessibility_moderation_pending(
+        self,
+        driver,
+        session,
+        provider,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
+        pending_page = RegistriesModerationPendingPage(driver, provider=provider)
+        pending_page.goto()
+        assert RegistriesModerationPendingPage(driver, verify=True)
+        # Wait for registration table to load before calling axe
+        if pending_page.no_registrations_message.absent():
+            WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-registration-list-card]')
+                )
+            )
+        a11y.run_axe(
+            driver,
+            session,
+            'regmodpend',
             write_files=write_files,
             exclude_best_practice=exclude_best_practice,
         )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
The Outcome Reporting/Registrations Versioning Project made changes to the Registries Moderation pages and the Registries Accessibility test needs to be updated to account for these changes.


## Summary of Changes

- pages/registries.py - renamed RegistriesModerationSubmissionsPage to RegistriesModerationSubmittedPage and added new class: RegistriesModerationPendingPage
- tests/test_a11y_registries.py - renamed RegistriesModerationSubmissionsPage to RegistriesModerationSubmittedPage and added new test: test_accessibility_moderation_pending to test the new Moderations Pending page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/registries`

Run this test using
`tests/test_a11y_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3427: SEL: A11y - Registries Test - Updates for Outcome Reporting/Registrations Versioning Project
https://openscience.atlassian.net/browse/ENG-3427
