### PR TITLE
[ENG-3369]  - Add write_files and exclude_best_practice flags to CAS tests

### DIFF
--- a/tests/test_a11y_cas.py
+++ b/tests/test_a11y_cas.py
@@ -17,11 +17,17 @@ from pages.login import (
 
 
 class TestCASLoginPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         login_page = LoginPage(driver)
         login_page.goto()
         assert LoginPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'login')
+        a11y.run_axe(
+            driver,
+            session,
+            'login',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 @markers.dont_run_on_prod
@@ -31,12 +37,18 @@ class TestLogin2FAPage:
     page.
     """
 
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         login(
             driver, user=settings.CAS_2FA_USER, password=settings.CAS_2FA_USER_PASSWORD
         )
         assert Login2FAPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'login2FA')
+        a11y.run_axe(
+            driver,
+            session,
+            'login2FA',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 @markers.dont_run_on_prod
@@ -46,24 +58,36 @@ class TestLoginToSPage:
     Service acceptance page.
     """
 
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         login(
             driver, user=settings.CAS_TOS_USER, password=settings.CAS_TOS_USER_PASSWORD
         )
         assert LoginToSPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'loginToS')
+        a11y.run_axe(
+            driver,
+            session,
+            'loginToS',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestInstitutionalLoginPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         institution_login_page = InstitutionalLoginPage(driver)
         institution_login_page.goto()
         assert InstitutionalLoginPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'i9nlogin')
+        a11y.run_axe(
+            driver,
+            session,
+            'i9nlogin',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestPreselectedInstitutionLoginPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         preselectUrl = (
             settings.CAS_DOMAIN
             + '/login?campaign=institution&institutionId=nd&service='
@@ -76,15 +100,27 @@ class TestPreselectedInstitutionLoginPage:
         assert driver.find_element(By.CSS_SELECTOR, '#institutionSelect').get_property(
             'disabled'
         )
-        a11y.run_axe(driver, session, 'i9npresel')
+        a11y.run_axe(
+            driver,
+            session,
+            'i9npresel',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestUnsupportedInstitutionLoginPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         unsupported_institution_page = UnsupportedInstitutionLoginPage(driver)
         unsupported_institution_page.goto()
         assert UnsupportedInstitutionLoginPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'unsupi9n')
+        a11y.run_axe(
+            driver,
+            session,
+            'unsupi9n',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestInstitutionForgotPasswordPage:
@@ -93,7 +129,7 @@ class TestInstitutionForgotPasswordPage:
     page in OSF.
     """
 
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         unsupported_institution_page = UnsupportedInstitutionLoginPage(driver)
         unsupported_institution_page.goto()
         assert UnsupportedInstitutionLoginPage(driver, verify=True)
@@ -101,21 +137,35 @@ class TestInstitutionForgotPasswordPage:
         # Forgot Password page. Don't need to first enter an email address.
         unsupported_institution_page.set_password_button.click()
         assert InstitutionForgotPasswordPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'i9nfrgtpswrd')
+        a11y.run_axe(
+            driver,
+            session,
+            'i9nfrgtpswrd',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 class TestGenericCASExceptionPage:
-    def test_accessibility(self, driver, session):
+    def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         """ Test the Service not authorized exception page by having an invalid service in the url
         """
         driver.get(settings.CAS_DOMAIN + '/login?service=https://noservice.osf.io/')
         assert GenericCASPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'genCASExcept')
+        a11y.run_axe(
+            driver,
+            session,
+            'genCASExcept',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
 
 
 @markers.dont_run_on_prod
 class TestCASOauthAuthorizationPage:
-    def test_accessibility(self, driver, session, must_be_logged_in):
+    def test_accessibility(
+        self, driver, session, write_files, exclude_best_practice, must_be_logged_in
+    ):
         """ Test the CAS Oauth Authorization page by building an authorization url using
         the required parameters and then navigating to that url. No need to complete the
         authorization process since we just want to evaluate the authorization page for
@@ -139,4 +189,10 @@ class TestCASOauthAuthorizationPage:
         # navigate to the authorization url in the browser
         driver.get(authorization_url)
         assert CASAuthorizationPage(driver, verify=True)
-        a11y.run_axe(driver, session, 'CASOauth')
+        a11y.run_axe(
+            driver,
+            session,
+            'CASOauth',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Enhancement to CAS accessibility test to add flags that disable the writing of output files and enable excluding best practice rules from accessibility check.


## Summary of Changes

- tests/test_a11y_cas.py -  adding write_files and exclude_best_practice flags to each of the CAS accessibility test steps


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/cas-flags`

Run this test using
`tests/test_a11y_cas.py -s -v --write_files false --exclude_best_practice true`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3369: SEL: Accessibility - Setup GitHub Actions in selenium-a11y repository
https://openscience.atlassian.net/browse/ENG-3369
