### PR TITLE
[ENG-3369] - Setup GitHub Actions for Accessibility Test Suite - Legacy Pages and CAS

### DIFF
--- a/.github/workflows/cas_a11y_tests.yml
+++ b/.github/workflows/cas_a11y_tests.yml
@@ -1,0 +1,109 @@
+name: CAS A11y Tests
+
+on:
+  repository_dispatch:
+    types: [code_deploy]
+    inputs:
+      domain:
+        description: 'Testing Environment'
+        required: true
+        default: 'stage1'
+        type: string
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Testing Environment'
+        required: true
+        default: 'stage1'
+
+env:
+  DRIVER: "Remote"
+  DOMAIN: ${{ github.event.inputs.domain }}
+  NEW_USER_EMAIL: ${{ secrets.NEW_USER_EMAIL }}
+  BSTACK_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BSTACK_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  CHROME_USER: ${{ secrets.CHROME_USER }}
+  CHROME_USER_TOKEN: ${{ secrets.CHROME_USER_TOKEN }}
+  EDGE_USER: ${{ secrets.EDGE_USER }}
+  EDGE_USER_TOKEN: ${{ secrets.EDGE_USER_TOKEN }}
+  FIREFOX_USER: ${{ secrets.FIREFOX_USER }}
+  FIREFOX_USER_TOKEN: ${{ secrets.FIREFOX_USER_TOKEN }}
+  USER_ONE: ${{ secrets.USER_ONE }}
+  USER_ONE_PASSWORD: ${{ secrets.USER_ONE_PASSWORD }}
+  USER_TWO: ${{ secrets.USER_TWO }}
+  USER_TWO_PASSWORD: ${{ secrets.USER_TWO_PASSWORD }}
+  DEACTIVATED_USER: ${{ secrets.DEACTIVATED_USER }}
+  DEACTIVATED_USER_PASSWORD: ${{ secrets.DEACTIVATED_USER_PASSWORD }}
+  UNCONFIRMED_USER: ${{ secrets.UNCONFIRMED_USER }}
+  UNCONFIRMED_USER_PASSWORD: ${{ secrets.UNCONFIRMED_USER_PASSWORD }}
+  CAS_2FA_USER: ${{ secrets.CAS_2FA_USER }}
+  CAS_2FA_USER_PASSWORD: ${{ secrets.CAS_2FA_USER_PASSWORD }}
+  CAS_TOS_USER: ${{ secrets.CAS_TOS_USER }}
+  CAS_TOS_USER_PASSWORD: ${{ secrets.CAS_TOS_USER_PASSWORD }}
+  DEVAPP_CLIENT_ID: ${{ secrets.DEVAPP_CLIENT_ID }}
+  DEVAPP_CLIENT_SECRET: ${{ secrets.DEVAPP_CLIENT_SECRET }}
+  IMAP_EMAIL: ${{ secrets.IMAP_EMAIL }}
+  IMAP_EMAIL_PASSWORD: ${{ secrets.IMAP_EMAIL_PASSWORD }}
+  IMAP_HOST: ${{ secrets.IMAP_HOST }}
+  A11Y_REGISTRATIONS_USER: ${{ secrets.A11Y_REGISTRATIONS_USER }}
+  A11Y_REGISTRATIONS_PASSWORD: ${{ secrets.A11Y_REGISTRATIONS_PASSWORD }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        python-version: [3.9.2]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache Build Requirements
+        id: pip-cache-step
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: install dependencies
+        if: steps.pip-cache-step.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          invoke requirements
+
+  staging_test:
+    name: Staging tests (${{ matrix.browser }})
+    needs: build
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1  # run in series
+      matrix:
+        browser: [chrome, firefox, edge]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9.2
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.2
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: run staging tests
+        env:
+          TEST_BUILD: ${{ matrix.browser }}
+        run: |
+          invoke test_cas_accessibility

--- a/.github/workflows/legacy_a11y_tests.yml
+++ b/.github/workflows/legacy_a11y_tests.yml
@@ -1,0 +1,109 @@
+name: Legacy A11y Tests
+
+on:
+  repository_dispatch:
+    types: [code_deploy]
+    inputs:
+      domain:
+        description: 'Testing Environment'
+        required: true
+        default: 'stage1'
+        type: string
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Testing Environment'
+        required: true
+        default: 'stage1'
+
+env:
+  DRIVER: "Remote"
+  DOMAIN: ${{ github.event.inputs.domain }}
+  NEW_USER_EMAIL: ${{ secrets.NEW_USER_EMAIL }}
+  BSTACK_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BSTACK_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  CHROME_USER: ${{ secrets.CHROME_USER }}
+  CHROME_USER_TOKEN: ${{ secrets.CHROME_USER_TOKEN }}
+  EDGE_USER: ${{ secrets.EDGE_USER }}
+  EDGE_USER_TOKEN: ${{ secrets.EDGE_USER_TOKEN }}
+  FIREFOX_USER: ${{ secrets.FIREFOX_USER }}
+  FIREFOX_USER_TOKEN: ${{ secrets.FIREFOX_USER_TOKEN }}
+  USER_ONE: ${{ secrets.USER_ONE }}
+  USER_ONE_PASSWORD: ${{ secrets.USER_ONE_PASSWORD }}
+  USER_TWO: ${{ secrets.USER_TWO }}
+  USER_TWO_PASSWORD: ${{ secrets.USER_TWO_PASSWORD }}
+  DEACTIVATED_USER: ${{ secrets.DEACTIVATED_USER }}
+  DEACTIVATED_USER_PASSWORD: ${{ secrets.DEACTIVATED_USER_PASSWORD }}
+  UNCONFIRMED_USER: ${{ secrets.UNCONFIRMED_USER }}
+  UNCONFIRMED_USER_PASSWORD: ${{ secrets.UNCONFIRMED_USER_PASSWORD }}
+  CAS_2FA_USER: ${{ secrets.CAS_2FA_USER }}
+  CAS_2FA_USER_PASSWORD: ${{ secrets.CAS_2FA_USER_PASSWORD }}
+  CAS_TOS_USER: ${{ secrets.CAS_TOS_USER }}
+  CAS_TOS_USER_PASSWORD: ${{ secrets.CAS_TOS_USER_PASSWORD }}
+  DEVAPP_CLIENT_ID: ${{ secrets.DEVAPP_CLIENT_ID }}
+  DEVAPP_CLIENT_SECRET: ${{ secrets.DEVAPP_CLIENT_SECRET }}
+  IMAP_EMAIL: ${{ secrets.IMAP_EMAIL }}
+  IMAP_EMAIL_PASSWORD: ${{ secrets.IMAP_EMAIL_PASSWORD }}
+  IMAP_HOST: ${{ secrets.IMAP_HOST }}
+  A11Y_REGISTRATIONS_USER: ${{ secrets.A11Y_REGISTRATIONS_USER }}
+  A11Y_REGISTRATIONS_PASSWORD: ${{ secrets.A11Y_REGISTRATIONS_PASSWORD }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        python-version: [3.9.2]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache Build Requirements
+        id: pip-cache-step
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: install dependencies
+        if: steps.pip-cache-step.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          invoke requirements
+
+  staging_test:
+    name: Staging tests (${{ matrix.browser }})
+    needs: build
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1  # run in series
+      matrix:
+        browser: [chrome, firefox, edge]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9.2
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.2
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: run staging tests
+        env:
+          TEST_BUILD: ${{ matrix.browser }}
+        run: |
+          invoke test_legacy_accessibility

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -86,6 +86,18 @@ def test_ember_accessibility(ctx):
 
 
 @task
+def test_legacy_accessibility(ctx):
+    """Run the accessibility test for Legacy pages on the browser defined by TEST_BUILD.
+    This task will be invoked after 'osf.io' has been deployed to any testing
+    environment.   In order to be included in this test run the test must have the
+    pytest marker 'legacy_page'.
+    """
+    test_with_retries(
+        ctx, 'Legacy Pages', _get_test_file_list(), module=['-m', 'legacy_page']
+    )
+
+
+@task
 def test_preprints_accessibility(ctx):
     """Run the accessibility test for Preprints on the browser defined by TEST_BUILD.
     This task will be invoked after 'ember-osf-preprints' has been deployed to any

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -75,7 +75,7 @@ def test_module(ctx, module=None, params=None):
 
 @task
 def test_ember_accessibility(ctx):
-    """Run the accessibility test for Ember pages on the browser defined by TEST_BUILD.
+    """Run the accessibility tests for Ember pages on the browser defined by TEST_BUILD.
     This task will be invoked after 'ember-osf-web' has been deployed to any testing
     environment.   In order to be included in this test run the test must have the
     pytest marker 'ember_page'.
@@ -87,7 +87,7 @@ def test_ember_accessibility(ctx):
 
 @task
 def test_legacy_accessibility(ctx):
-    """Run the accessibility test for Legacy pages on the browser defined by TEST_BUILD.
+    """Run the accessibility tests for Legacy pages on the browser defined by TEST_BUILD.
     This task will be invoked after 'osf.io' has been deployed to any testing
     environment.   In order to be included in this test run the test must have the
     pytest marker 'legacy_page'.
@@ -105,6 +105,16 @@ def test_preprints_accessibility(ctx):
     """
     file_list = ['tests/test_a11y_preprints.py']
     test_with_retries(ctx, 'Preprints', file_list)
+
+
+@task
+def test_cas_accessibility(ctx):
+    """Run the accessibility test for CAS on the browser defined by TEST_BUILD.
+    This task will be invoked after 'osf-cas' has been deployed to any testing
+    environment.
+    """
+    file_list = ['tests/test_a11y_cas.py']
+    test_with_retries(ctx, 'CAS', file_list)
 
 
 def _get_test_file_list():


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To setup GitHub Action Workflows in the selenium-a11y repository so that the accessibility tests for Legacy pages and CAS can be triggered and run after deployment of code releases to any of the staging environments.


## Summary of Changes

- .github/workflows/cas_a11y_tests.yml - new YAML file to define the GitHub Actions workflow for running the accessibility tests that are specific to CAS pages.
- .github/workflows/legacy_a11y_tests.yml - new YAML file to define the GitHub Actions workflow for running the accessibility tests that are specific to Legacy pages.
- tasks/__init__.py - adding new tasks to run the CAS and Legacy pages accessibility tests


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/github-actions`

Run this test using
invoke test_cas_accessibility
invoke test_legacy_accessibility


## Testing Changes Moving Forward
N/A


## Ticket
ENG-3369: SEL: Accessibility - Setup GitHub Actions in selenium-a11y repository
https://openscience.atlassian.net/browse/ENG-3369
