### PR TITLE
[ENG-3547] - Enable use of MS Edge with Selenium Accessibility tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,10 @@
 
 ## Which browser/software stack to run the tests under.
 
-## DRIVER: which browser to test in.  Valid options are 'Chrome', 'Firefox', 'Remote'
+## DRIVER: which browser to test in.  Valid options are 'Chrome', 'Firefox', 'Edge', Remote'
 ##   'Chrome' requires that chromedriver is available in $PATH
 ##   'Firefox' requires that geckodriver is available in $PATH
+##   'Edge' requires that msedgedriver is available in $PATH
 ##   'Remote' will run the tests via BrowserStack
 ##
 ## HEADLESS: Should selenium hide the browser gui as the tests are being run?

--- a/utils.py
+++ b/utils.py
@@ -75,6 +75,14 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             'application/excel, text/comma-separated-values, text/xml, application/xml',
         )
         driver = driver_cls(firefox_profile=ffp)
+    elif driver_name == 'Edge' and not settings.HEADLESS:
+        from msedge.selenium_tools import Edge
+
+        # Need to set the flag so that we use the newer Chromium based version of Edge
+        # instead of older IE based version of Edge
+        desired_capabilities = {'ms:edgeChromium': True}
+        driver = Edge(desired_capabilities=desired_capabilities)
+
     else:
         driver = driver_cls()
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the capability of our Selenium Accessibility test suite to run tests using the Edge browser on local machines.

## Summary of Changes

- .env.example - updating example documentation to include Edge as a browser option
- utils.py - adding Edge specific elif clause to launch_driver method, including flag to tell Selenium to use the Chromium version of the MS Edge driver.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/edge`

Run this test using
run any test in our test suite after following the instructions to install MS Edge Driver and MS Edge Selenium Tools here: https://www.notion.so/cos/Selenium-Setup-Guide-8aaae9ff126a4311aa09daeacae24a1a#26974ad5bd4a48fe854320bfb20a42bc and also setting DRIVER=Edge in your .env file.

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3547: SEL: A11y - Add MS Edge to accessibility test suite
https://openscience.atlassian.net/browse/ENG-3547
