### PR TITLE
[ENG-3643] - Add a11y tests for Registration Files Pages

### DIFF
--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -34,6 +34,7 @@ class MyRegistrationsPage(OSFBasePage):
     draft_registration_cards = GroupLocator(
         By.CSS_SELECTOR, 'div[data-test-draft-registration-card]'
     )
+    registration_cards = GroupLocator(By.CSS_SELECTOR, 'div[data-test-node-card]')
 
     def get_first_draft_id_by_template(self, template_name):
         for draft_card in self.draft_registration_cards:
@@ -44,3 +45,13 @@ class MyRegistrationsPage(OSFBasePage):
                 ).get_attribute('href')
                 draft_id = url.split('drafts/', 1)[1]
                 return draft_id
+
+    def get_node_id_by_title(self, title):
+        for registration_card in self.registration_cards:
+            node_title = registration_card.find_element_by_css_selector(
+                '[data-test-node-title]'
+            )
+            if title in node_title.text:
+                url = node_title.get_attribute('href')
+                node_id = url.split('osf.io/', 1)[1]
+                return node_id

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -65,9 +65,32 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
                 )
 
 
-class RegistrationDetailPage(GuidBasePage):
+class BaseSubmittedRegistrationPage(GuidBasePage):
+    base_url = settings.OSF_HOME
+    url_addition = ''
+
+    @property
+    def url(self):
+        return self.base_url + '/' + self.guid + '/' + self.url_addition
+
+
+class RegistrationDetailPage(BaseSubmittedRegistrationPage):
+    """This is the Registration Overview Page"""
+
     identity = Locator(By.CSS_SELECTOR, '[data-test-registration-title]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
+
+
+class RegistrationFileListPage(BaseSubmittedRegistrationPage):
+    url_addition = 'files'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-file-providers-list]')
+    file_list_button = Locator(By.CSS_SELECTOR, '[data-test-file-list-link]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    first_file_link = Locator(By.CSS_SELECTOR, '[data-analytics-name="Open file"]')
+
+
+class RegistrationFileDetailPage(GuidBasePage):
+    identity = Locator(By.CSS_SELECTOR, '[data-test-file-renderer')
 
 
 class RegistrationAddNewPage(BaseRegistriesPage):

--- a/utils.py
+++ b/utils.py
@@ -63,6 +63,7 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         driver = driver_cls(chrome_options=chrome_options)
     elif driver_name == 'Firefox' and not settings.HEADLESS:
         from selenium.webdriver import FirefoxProfile
+        from selenium.webdriver.firefox.options import Options
 
         ffp = FirefoxProfile()
         # Set the default download location [0=Desktop, 1=Downloads, 2=Specified location]
@@ -74,7 +75,12 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
             'application/excel, text/comma-separated-values, text/xml, application/xml',
         )
-        driver = driver_cls(firefox_profile=ffp)
+        # Force Firefox to open links in new tab instead of new browser window. Have to
+        # use Options instead of Firefox Profile because the profile preference doesn't
+        # work.
+        ffo = Options()
+        ffo.set_preference('browser.link.open_newwindow', 3)
+        driver = driver_cls(firefox_profile=ffp, options=ffo)
     elif driver_name == 'Edge' and not settings.HEADLESS:
         from msedge.selenium_tools import Edge
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add new test steps to test the accessibility of the new Files List Page and File Detail Page for Registrations that are being added as part of the Files Page Redesign Phase I Project.


## Summary of Changes

- pages/registrations.py - add new function: get_node_id_by_title which searches through the registrations on the Submitted tab of the My Registrations page for a registration that matches a given title. When found the node id of the registration is returned.
- pages/registries.py - add new page classes: BaseSubmittedRegistrationPage, RegistrationFileListPage, and RegistrationFileDetailPage.
- tests/test_a11y_registries.py - add new test class: TestSubmittedRegistrationPages with new tests: test_accessibility_files_list_page and test_accessibility_file_detail_page.
- utils.py - Update Firefox Options to force Firefox to open links in new tab instead of a new browser window.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/registries-files`

Run this test using
`tests/test_a11y_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3643: SEL: A11y - Registries Test - Add Test Steps for Registration Files Pages
https://openscience.atlassian.net/browse/ENG-3643
