### PR TITLE
[ENG-3759] - Update axe to version 4.4.1

### DIFF
--- a/components/accessibility.py
+++ b/components/accessibility.py
@@ -33,23 +33,17 @@ class ApplyA11yRules:
         # Run axe accessibility checks.
         if exclude_best_practice:
             # When exclude_best_practice parameter is set to True, then we want to run
-            # axe with only the WCAG rule sets.  Also excluding element with id 'search'
-            # which is a bit of a hack since the python version of axe that we are using
-            # is outdated and is failing on the search input box on the Registry Discover
-            # pages (including all of the branded registry providers) since the search
-            # input box has an explicit label that has hidden style attributes. The
-            # element does not violate the missing form element label rule in more
-            # up-to-date versions of axe-core like the browser extension tool.
+            # axe with only the WCAG rule sets.
             results = axe.run(
-                context={
-                    'exclude': [
-                        ['#search'],
-                        ['.text-center'],
-                        ['._StateText_1iudhh'],
-                        ['._UpdateText_1u9k9o'],
-                        ['#oneTimePassword'],
-                    ]
-                },
+                # context={
+                #     'exclude': [
+                #         ['#search'],
+                #         ['.text-center'],
+                #         ['._StateText_1iudhh'],
+                #         ['._UpdateText_1u9k9o'],
+                #         ['#oneTimePassword'],
+                #     ]
+                # },
                 options={
                     'runOnly': {
                         'type': 'tag',

--- a/pages/landing.py
+++ b/pages/landing.py
@@ -10,6 +10,8 @@ from pages.base import OSFBasePage
 class LandingPage(OSFBasePage):
     identity = Locator(By.CSS_SELECTOR, '._heroHeader_1qc5dv', settings.LONG_TIMEOUT)
 
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
     # Components
     navbar = ComponentLocator(EmberNavbar)
     sign_up_form = ComponentLocator(SignUpForm)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ environs==3.0.0
 faker==0.9.0
 pre-commit==1.18.3
 ipdb==0.12.2
-axe-selenium-python==2.1.6
+git+https://github.com/DougCorell/axe-selenium-python.git@fix/update-axe-core-441#egg=axe-selenium-python
 pandas==1.2.4
 isort==5.9.3
 black==22.3.0

--- a/tests/test_a11y_other_osf.py
+++ b/tests/test_a11y_other_osf.py
@@ -1,6 +1,9 @@
 import re
 
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
@@ -21,6 +24,9 @@ class TestOSFHomePage:
         landing_page = LandingPage(driver)
         landing_page.goto()
         assert LandingPage(driver, verify=True)
+        # Need to wait for page to fully load (especially backgrounds and css styling)
+        # in order to avoid some false color contrast failures.
+        landing_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,
@@ -38,6 +44,12 @@ class TestDashboardPage:
         dashboard_page = DashboardPage(driver)
         dashboard_page.goto()
         assert DashboardPage(driver, verify=True)
+        # Need to wait for institutions carousel to load
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-institution-carousel-item]')
+            )
+        )
         a11y.run_axe(
             driver,
             session,


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To bring the selenium accessibility tests up to date with the most recent version of the axe-core testing engine (version 4.4.1)


## Summary of Changes

- components/accessibility.py - removing exclusion clause from axe run call that was meant to compensate for the fact that we were several versions behind the most recent axe-core version.
- pages/landing.py - adding a loading indicator definition for the main OSF Home landing page.
- requirements.txt - changing axe-selenium-python reference to use different branch with up to date axe-core version
- tests/test_a11y_other_osf.py - adding a few extra wait steps to enable more accurate accessibility evaluations of OSF Home Landing page and Dashboard page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/axe-core-update`

Run this test using
`pytest -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3759: SEL: A11y - Update axe-selenium-python to use the most recent version of axe-core
https://openscience.atlassian.net/browse/ENG-3759
