### PR TITLE
[ENG-3717] - Refactor Project Files Page a11y tests after Files Page Redesign Phase 2

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -1,7 +1,6 @@
 from selenium.webdriver.common.by import By
 
 import settings
-from api import osf_api
 from base.locators import ComponentLocator, GroupLocator, Locator
 from components.dashboard import (
     CreateCollectionModal,
@@ -98,33 +97,14 @@ class ForksPage(GuidBasePage):
 class FilesPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/files/'
 
-    identity = Locator(By.CSS_SELECTOR, '#treeGrid')
-    session = osf_api.get_default_session()
-    fangorn_rows = GroupLocator(By.CSS_SELECTOR, '#tb-tbody .fg-file-links')
-    fangorn_addons = GroupLocator(By.CSS_SELECTOR, "div[data-level='2']")
-    file_action_buttons = GroupLocator(
-        By.CSS_SELECTOR, '#folderRow .fangorn-toolbar-icon'
-    )
-    delete_modal = Locator(By.CSS_SELECTOR, 'span.btn:nth-child(1)')
-    loading_indicator = Locator(
-        By.CSS_SELECTOR, '#treeGrid > .ball-scale', settings.LONG_TIMEOUT
-    )
+    identity = Locator(By.CSS_SELECTOR, '[data-test-file-search]')
 
-
-"""Note that the class FilesPage in pages/project.py is used for test_project_files.py.
-The class FileWidget in components/project.py is used for tests test_file_widget_loads
-and test_addon_files_load in test_project.py.
-In the future, we may want to put all files tests in one place."""
+    file_rows = GroupLocator(By.CSS_SELECTOR, 'span[data-test-file-name]')
 
 
 class FileViewPage(GuidBasePage):
 
-    identity = Locator(By.ID, 'fileTitleEditable', settings.LONG_TIMEOUT)
-    file_nav_loading_indicator = Locator(
-        By.CSS_SELECTOR,
-        '#file-navigation > div > div > #grid > div > .ball-scale',
-        settings.LONG_TIMEOUT,
-    )
+    identity = Locator(By.CSS_SELECTOR, 'h2[data-test-filename]')
 
 
 class WikiPage(GuidBasePage):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To refactor the accessibility tests for the Project Files page and File Detail page after the release of the new Files Page Redesign Phase 2 project.


## Summary of Changes

- pages/project.py - removal of old legacy page locators, most of which were not used by the a11y tests anyway, and replacing them with new ember page locators.
- teste/test_a11y_project.py - refactoring the tests in classes: TestFilesPage and TestFileViewPage to account for the change from legacy pages to ember pages.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/files_page_phase2`

Run this test using
`tests/test_a11y_project.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3717: SEL: A11y - Project Test - Refactor Files Page and File View Page Tests For Files Page Redesign Phase 2
https://openscience.atlassian.net/browse/ENG-3717
