### PR TITLE
[ENG-3793] - Add creation of draft registration to Project Registrations page test

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -118,6 +118,10 @@ class RegistrationsPage(GuidBasePage):
 
     identity = Locator(By.CSS_SELECTOR, '[data-test-registrations-container]')
     first_registration_title = Locator(By.CSS_SELECTOR, '[data-test-node-title]')
+    draft_registrations_tab = Locator(By.CSS_SELECTOR, '[data-test-drafts-tab]')
+    draft_registration_card = Locator(
+        By.CSS_SELECTOR, '[data-test-draft-registration-card]'
+    )
 
 
 class ContributorsPage(GuidBasePage):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To enhance the accessibility test for the Project Registrations page to include a draft registration on the Draft Registrations tab.


## Summary of Changes

- api/osf_api.py - adding 2 new functions: get_registration_schemas_for_provider and create_draft_registration that were previously added to osf_api.py in the osf-selenium-tests repo.
- pages/project.py - adding a couple of new locators to the RegistrationsPage class.
- tests/test_a11y_project.py - adding new code to the TestRegistrationsPage class to create a draft registration using the OSF api and attaching it to a dummy project when running in one of the non-Production environments.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project-registrations`

Run this test using
`tests/test_a11y_project.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3793: SEL: A11y - Project Test - TestRegistrationsPage - Use API to Create Draft Registration
https://openscience.atlassian.net/browse/ENG-3793
