### PR TITLE
[ENG-3889] - Registration and Project File Detail Page a11y tests - Close second tab after tests

### DIFF
--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -97,33 +97,42 @@ class TestFileViewPage:
         then deleting it after we have finished unless we are running in Production,
         then we are using a Preferred Node from the environment settings file.
         """
-        files_page = FilesPage(driver, guid=project_with_file.id)
-        files_page.goto()
-        # Wait until at least one of the files in the list is present
-        WebDriverWait(driver, 5).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, '[data-test-select-file]'))
-        )
-        for file in files_page.file_rows:
-            # open the first text file you find
-            if '.txt' in file.text:
-                file.click()
-                break
-        # Wait for the new tab to open - window count should then = 2
-        WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
-        # Switch focus to the new tab
-        driver.switch_to.window(driver.window_handles[1])
-        assert FileViewPage(driver, verify=True)
-        # wait for iframe to load before running axe
-        WebDriverWait(driver, 10).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR, '#mfrIframeParent'))
-        )
-        a11y.run_axe(
-            driver,
-            session,
-            'fileView',
-            write_files=write_files,
-            exclude_best_practice=exclude_best_practice,
-        )
+        try:
+            files_page = FilesPage(driver, guid=project_with_file.id)
+            files_page.goto()
+            # Wait until at least one of the files in the list is present
+            WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-select-file]')
+                )
+            )
+            for file in files_page.file_rows:
+                # open the first text file you find
+                if '.txt' in file.text:
+                    file.click()
+                    break
+            # Wait for the new tab to open - window count should then = 2
+            WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
+            # Switch focus to the new tab
+            driver.switch_to.window(driver.window_handles[1])
+            assert FileViewPage(driver, verify=True)
+            # wait for iframe to load before running axe
+            WebDriverWait(driver, 10).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, '#mfrIframeParent'))
+            )
+            a11y.run_axe(
+                driver,
+                session,
+                'fileView',
+                write_files=write_files,
+                exclude_best_practice=exclude_best_practice,
+            )
+        finally:
+            # Close the second tab that was opened. We do not want subsequent tests to
+            # use the second tab.
+            driver.close()
+            # Switch focus back to the first tab
+            driver.switch_to.window(driver.window_handles[0])
 
 
 @markers.legacy_page

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -239,27 +239,34 @@ class TestSubmittedRegistrationPages:
                 (By.CSS_SELECTOR, '[data-test-file-list-item]')
             )
         )
-        # Click the first file from the list to open the File Detail page in a new tab
-        registration_file_list_page.scroll_into_view(
-            registration_file_list_page.first_file_link.element
-        )
-        registration_file_list_page.first_file_link.click()
-        # Wait for the new tab to open - window count should then = 2
-        WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
-        # Switch focus to the new tab
-        driver.switch_to.window(driver.window_handles[1])
-        assert RegistrationFileDetailPage(driver)
-        # Wait for File Renderer to load
-        WebDriverWait(driver, 5).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR, 'iframe'))
-        )
-        a11y.run_axe(
-            driver,
-            session,
-            'regfiledet',
-            write_files=write_files,
-            exclude_best_practice=exclude_best_practice,
-        )
+        try:
+            # Click the first file from the list to open the File Detail page in a new tab
+            registration_file_list_page.scroll_into_view(
+                registration_file_list_page.first_file_link.element
+            )
+            registration_file_list_page.first_file_link.click()
+            # Wait for the new tab to open - window count should then = 2
+            WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
+            # Switch focus to the new tab
+            driver.switch_to.window(driver.window_handles[1])
+            assert RegistrationFileDetailPage(driver)
+            # Wait for File Renderer to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR, 'iframe'))
+            )
+            a11y.run_axe(
+                driver,
+                session,
+                'regfiledet',
+                write_files=write_files,
+                exclude_best_practice=exclude_best_practice,
+            )
+        finally:
+            # Close the second tab that was opened. We do not want subsequent tests to
+            # use the second tab.
+            driver.close()
+            # Switch focus back to the first tab
+            driver.switch_to.window(driver.window_handles[0])
 
 
 # User with registrations is not setup in production


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Both the Project File Detail page test and the Registrations File Detail page test open a second tab in the browser with the file to be viewed and evaluated for accessibility.  This second tab then remains the tab with focus for all subsequent tests that are run in the same session.  This can cause issues, so we want to close the second tab immediately after the accessibility test has been run for each page.


## Summary of Changes

- tests/test_a11y_project.py - add finally clause that closes the second tab and resets focus to the first tab.
- tests/test_a11y_registries.py - add finally clause that closes the second tab and resets focus to the first tab.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/close-second-tabs`

Run this test using
`tests/test_a11y_project.py -s -v`
`tests/test_a11y_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3889: SEL: A11y - Registration File Detail Page - Test Failure When Run From GitHub Actions
https://openscience.atlassian.net/browse/ENG-3889
