### PR TITLE
[ENG-3986] - Add a11y test for Registrations Resources page

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -92,6 +92,11 @@ class RegistrationFileDetailPage(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-file-renderer')
 
 
+class RegistrationResourcesPage(BaseSubmittedRegistrationPage):
+    url_addition = 'resources'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-add-resource-section]')
+
+
 class RegistrationAddNewPage(BaseRegistriesPage):
     url_addition = 'new'
     identity = Locator(


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add a new accessibility test to cover the new Registrations Resources page added as part of Outcome Reporting project.


## Summary of Changes

- pages/regsitries.py - add new page class definition: RegistrationResourcesPage
- tests/test_a11y_registries.py - add new test: test_accessibility_resources_page


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/registrations-resources`

Run this test using
`tests/test_a11y_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3986: SEL: A11y - Add Test for Registrations Resources Page
https://openscience.atlassian.net/browse/ENG-3986
