### PR TITLE
[ENG-4233] - Add A11y Tests for Collections Moderation Pages

### DIFF
--- a/pages/collections.py
+++ b/pages/collections.py
@@ -48,3 +48,41 @@ class CollectionSubmitPage(BaseCollectionPage):
     project_metadata_save = Locator(
         By.CSS_SELECTOR, '[data-test-project-metadata-save-button]'
     )
+
+
+class CollectionModerationPendingPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=pending#'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type="pending"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionModerationAcceptedPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=accepted#'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type="accepted"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionModerationRejectedPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=rejected'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type="rejected"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionModerationRemovedPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=removed'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-submissions-type="removed"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionModerationModeratorsPage(BaseCollectionPage):
+    url_addition = 'moderation/moderators'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-moderator-row]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionModerationSettingsPage(BaseCollectionPage):
+    url_addition = 'moderation/settings'
+    identity = Locator(
+        By.CSS_SELECTOR, '[data-test-collections-moderation-settings-heading]'
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add new accessibility tests for the new Collections Moderation pages.


## Summary of Changes

- pages/collections.py - add 6 new page classes for the new Collections Moderation pages
- tests/test_a11y_collections.py - add 6 new accessibility tests for the new Collections Moderation pages, and update the providers fixture in the TestCollectionDiscoverPages class to filter out excess collections pages in the testing environments.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/collections-moderation`

Run this test using
`tests/test_a11y_collections.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4233: SEL: A11y - Add Test for Collections Moderation Pages
https://openscience.atlassian.net/browse/ENG-4233
