### PR TITLE
[ENG-4305] Add New A11y Tests for Metadata Pages

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -68,6 +68,13 @@ class MyProjectsPage(OSFBasePage):
     project_created_modal = ComponentLocator(ProjectCreatedModal)
 
 
+class MetadataPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/metadata/'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Node"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+
+
 class AnalyticsPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/analytics/'
 

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -68,6 +68,14 @@ class BaseSubmittedRegistrationPage(GuidBasePage):
     base_url = settings.OSF_HOME
     url_addition = ''
 
+    def __init__(self, driver, verify=False, guid=''):
+        # Set the cookie that prevents the New Feature popover from appearing on
+        # submitted registration pages since this popover can get in the way of other
+        # actions.
+        driver.add_cookie({'name': 'metadataFeaturePopover', 'value': '1'})
+
+        super().__init__(driver, verify, guid)
+
     @property
     def url(self):
         return self.base_url + '/' + self.guid + '/' + self.url_addition

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -97,6 +97,12 @@ class RegistrationResourcesPage(BaseSubmittedRegistrationPage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-add-resource-section]')
 
 
+class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
+    url_addition = 'metadata'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-edit-resource-metadata-button]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
 class RegistrationAddNewPage(BaseRegistriesPage):
     url_addition = 'new'
     identity = Locator(

--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -13,6 +13,7 @@ from pages.project import (
     FilesPage,
     FileViewPage,
     ForksPage,
+    MetadataPage,
     ProjectPage,
     RegistrationsPage,
     RequestAccessPage,
@@ -46,6 +47,34 @@ class TestProjectPage:
             driver,
             session,
             'project',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
+
+
+@markers.ember_page
+class TestMetadataPage:
+    def test_accessibility(
+        self,
+        driver,
+        session,
+        default_project,
+        write_files,
+        exclude_best_practice,
+        must_be_logged_in,
+    ):
+        """For the Project Metadata page test we are creating a new dummy test project
+        and then deleting it after we have finished unless we are running in Production,
+        then we are using a Preferred Node from the environment settings file.
+        """
+        metadata_page = MetadataPage(driver, guid=default_project.id)
+        metadata_page.goto()
+        assert MetadataPage(driver, verify=True)
+        metadata_page.loading_indicator.here_then_gone()
+        a11y.run_axe(
+            driver,
+            session,
+            'prjMeta',
             write_files=write_files,
             exclude_best_practice=exclude_best_practice,
         )

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -170,10 +170,7 @@ class TestSubmittedRegistrationPages:
         """
         my_registrations_page = MyRegistrationsPage(driver)
         my_registrations_page.goto()
-        # Set the cookie that prevents the New Feature popover from appearing on
-        # submitted registration pages since this popover can get in the way of other
-        # actions.
-        driver.add_cookie({'name': 'outputFeaturePopover', 'value': '1'})
+
         # Wait for registration cards to load on page
         WebDriverWait(driver, 5).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '[data-test-node-card]'))

--- a/tests/test_a11y_registries.py
+++ b/tests/test_a11y_registries.py
@@ -18,6 +18,7 @@ from pages.registries import (
     RegistrationDetailPage,
     RegistrationFileDetailPage,
     RegistrationFileListPage,
+    RegistrationMetadataPage,
     RegistrationResourcesPage,
     RegistriesDiscoverPage,
     RegistriesLandingPage,
@@ -302,6 +303,34 @@ class TestSubmittedRegistrationPages:
             driver,
             session,
             'regresources',
+            write_files=write_files,
+            exclude_best_practice=exclude_best_practice,
+        )
+
+    @markers.ember_page
+    def test_accessibility_metadata_page(
+        self, driver, session, write_files, exclude_best_practice, my_registrations_page
+    ):
+        """This test is for checking the accessibility of the Registration Metadata
+        Page of a submitted registration.  First search through the registration cards
+        on the Submitted tab of the My Registration Page for a specific registration
+        (searching by registration title).  When you find the desired registration get
+        the registration node id from its link and then use the node id to navigate to
+        the Meatadata page for this registration.
+        """
+        registration_node = my_registrations_page.get_node_id_by_title(
+            'Registration With Files for A11y Testing'
+        )
+        registration_metadata_page = RegistrationMetadataPage(
+            driver, guid=registration_node
+        )
+        registration_metadata_page.goto()
+        assert RegistrationMetadataPage(driver, verify=True)
+        registration_metadata_page.loading_indicator.here_then_gone()
+        a11y.run_axe(
+            driver,
+            session,
+            'regmeta',
             write_files=write_files,
             exclude_best_practice=exclude_best_practice,
         )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add new tests to test the accessibility of the new node Metadata pages.


## Summary of Changes

- pages/project.py - add new page class: MetadataPage
- pages/registries.py - add new page class: RegistrationMetadataPage; also add setting of cookie 'metadataFeaturePopover' to init of BaseSubmittedRegistrationPage class
- tests/test_a11y_project.py - add new test class: TestMetadataPage with new accessibility test
- tests/test_a11y_registries.py - add new test: test_accessibility_metadata_page


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/metadata`

Run this test using
`tests/test_a11y_project.py -s -v`
`tests/test_a11y_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4305: SEL: A11y - Add Tests for Node Metadata Page for Project and Registration
https://openscience.atlassian.net/browse/ENG-4305
