### PR TITLE
[ENG-4332] - Fix collections submit page test failure due to license validation

### DIFF
--- a/pages/collections.py
+++ b/pages/collections.py
@@ -38,6 +38,7 @@ class CollectionSubmitPage(BaseCollectionPage):
     url_addition = 'submit'
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-test-collections-submit-sections]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     project_selector = Locator(
         By.CSS_SELECTOR, 'span[class="ember-power-select-placeholder"]'
     )

--- a/tests/test_a11y_collections.py
+++ b/tests/test_a11y_collections.py
@@ -1,6 +1,5 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -80,17 +79,10 @@ class TestCollectionSubmitPage:
         submit_page = CollectionSubmitPage(driver, provider=provider)
         submit_page.goto()
         assert CollectionSubmitPage(driver, verify=True)
-        # Continue process until Project contributors section is expanded before
-        #     calling axe
         submit_page.project_selector.click()
         submit_page.project_help_text.here_then_gone()
         submit_page.project_selector_project.click()
-        submit_page.project_metadata_save.click()
-        WebDriverWait(driver, 5).until(
-            EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '[data-test-project-contributors-list-item-name]')
-            )
-        )
+        submit_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a test failure in the Collections Submit Page a11y test due to recent code changes that enforce license validation.


## Summary of Changes

- pages/collections.py - add loading_indicator element to Collections Submit page
- tests/test_a11y_collections.py - delete steps that tried to get past Project Metadata section before performing accessibility check


## Reviewer's Actions
`git fetch <remote> pull/41/head:testFix/collections-submit`

Run this test using
`tests/test_a11y_collections.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4332: SEL: A11y - Collections Submit Page - Test Failure
https://openscience.atlassian.net/browse/ENG-4332
