### PR TITLE
[ENG-4543] - Update Analytics Page graph element locator after Keen replacement

### DIFF
--- a/tests/test_a11y_project.py
+++ b/tests/test_a11y_project.py
@@ -211,7 +211,7 @@ class TestAnalyticsPage:
         assert AnalyticsPage(driver, verify=True)
         # wait until analytics graphs load
         WebDriverWait(driver, 5).until(
-            EC.visibility_of_element_located((By.CSS_SELECTOR, '.keen-dataviz-stage'))
+            EC.visibility_of_element_located((By.CSS_SELECTOR, '[data-test-analytics-chart]'))
         )
         a11y.run_axe(
             driver,


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix test failure in 'tests/test_a11y_project.py::TestAnalyticsPage::test_accessibility' due to an invalid element locator after Keen was replaced as metrics source.


## Summary of Changes

- tests/test_a11y_project.py - update element locator in WebDriverWait statement in 'TestAnalyticsPage::test_accessibility'


## Reviewer's Actions
`git fetch <remote> pull/42/head:testFix/analytics-keen-replacement`

Run this test using
`tests/test_a11y_project.py::TestAnalyticsPage::test_accessibility -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4543: SEL: A11y - Project Analytics Page Test - Update after Keen Replacement
https://openscience.atlassian.net/browse/ENG-4543
