### PR TITLE
[ENG-4614] - Updates for Search Improvements Project

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -370,3 +370,16 @@ def create_draft_registration(session, node_id=None, schema_id=None):
     session.post(
         url=url, item_type='draft_registrations', raw_body=json.dumps(raw_payload)
     )
+
+
+def get_most_recent_preprint_node_id(session=None):
+    """Return the most recently published preprint node id"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/preprints/'
+    data = session.get(url)['data']
+    if data:
+        for preprint in data:
+            if preprint['attributes']['is_published']:
+                return preprint['id']
+    return None

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -383,3 +383,25 @@ def get_most_recent_preprint_node_id(session=None):
             if preprint['attributes']['is_published']:
                 return preprint['id']
     return None
+
+
+def get_most_recent_registration_node_id(session=None):
+    """Return the most recently approved public registration node id. The
+    /v2/registrations endpoint currently returns the most recently modified
+    registration sorted first. But we still need to check for a public and
+    approved registration that has not been withdrawn in order to get a
+    registration that is fully accessible.
+    """
+    if not session:
+        session = get_default_session()
+    url = '/v2/registrations/'
+    data = session.get(url)['data']
+    if data:
+        for registration in data:
+            if (
+                registration['attributes']['public']
+                and (registration['attributes']['revision_state'] == 'approved')
+                and not registration['attributes']['withdrawn']
+            ):
+                return registration['id']
+    return None

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -1,10 +1,9 @@
 from urllib.parse import urljoin
 
-import pytest
 from selenium.webdriver.common.by import By
 
 import settings
-from base.locators import ComponentLocator, GroupLocator, Locator
+from base.locators import ComponentLocator, Locator
 from components.navbars import PreprintsNavbar
 from pages.base import GuidBasePage, OSFBasePage
 
@@ -145,23 +144,6 @@ class PreprintSubmitPage(BasePreprintPage):
         '.modal-footer button.btn-success:nth-child(2)',
         settings.LONG_TIMEOUT,
     )
-
-
-@pytest.mark.usefixtures('must_be_logged_in')
-class PreprintDiscoverPage(BasePreprintPage):
-    url_addition = 'discover'
-
-    identity = Locator(By.ID, 'share-logo')
-    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
-    search_box = Locator(By.ID, 'searchBox')
-    sort_button = Locator(By.ID, 'sortBy')
-    sort_option_newest_to_oldest = Locator(
-        By.CSS_SELECTOR, '#sortByOptionList > li:nth-child(3) > button'
-    )
-
-    # Group Locators
-    search_results = GroupLocator(By.CSS_SELECTOR, '.search-result h4 > a')
-    no_results = GroupLocator(By.CSS_SELECTOR, '.search-results-section .text-muted')
 
 
 class PreprintDetailPage(GuidBasePage, BasePreprintPage):

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -158,6 +158,7 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 class ReviewsDashboardPage(OSFBasePage):
     url = settings.OSF_HOME + '/reviews'
     identity = Locator(By.CLASS_NAME, '_reviews-dashboard-header_jdu5ey')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
 
 class BaseReviewsPage(OSFBasePage):
@@ -191,7 +192,10 @@ class BaseReviewsPage(OSFBasePage):
 
 
 class ReviewsSubmissionsPage(BaseReviewsPage):
-    identity = Locator(By.CLASS_NAME, '_reviews-list-heading_k45x8p')
+    identity = Locator(
+        By.CLASS_NAME, '_reviews-list-heading_k45x8p', settings.LONG_TIMEOUT
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     no_submissions = Locator(
         By.CSS_SELECTOR,
         'div._reviews-list-body_k45x8p > div.text-center.p-v-md._moderation-list-row_xkm0pa',
@@ -201,6 +205,7 @@ class ReviewsSubmissionsPage(BaseReviewsPage):
 class ReviewsWithdrawalsPage(BaseReviewsPage):
     url_addition = 'withdrawals'
     identity = Locator(By.CLASS_NAME, '_reviews-list-heading_k45x8p')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     no_requests = Locator(
         By.CSS_SELECTOR,
         'div._reviews-list-body_k45x8p > div.text-center.p-v-md._moderation-list-row_xkm0pa',
@@ -210,13 +215,16 @@ class ReviewsWithdrawalsPage(BaseReviewsPage):
 class ReviewsModeratorsPage(BaseReviewsPage):
     url_addition = 'moderators'
     identity = Locator(By.CLASS_NAME, 'moderator-list-row')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
 
 class ReviewsNotificationsPage(BaseReviewsPage):
     url_addition = 'notifications'
     identity = Locator(By.CLASS_NAME, '_notification-list-heading-container_kchmy0')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
 
 class ReviewsSettingsPage(BaseReviewsPage):
     url_addition = 'settings'
     identity = Locator(By.CLASS_NAME, '_reviews-settings_1r3x0j')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -1,10 +1,9 @@
 from urllib.parse import urljoin
 
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 import settings
-from base.locators import ComponentLocator, GroupLocator, Locator
+from base.locators import ComponentLocator, Locator
 from components.navbars import RegistriesNavbar
 from pages.base import GuidBasePage, OSFBasePage
 
@@ -37,29 +36,14 @@ class RegistriesLandingPage(BaseRegistriesPage):
     search_box = Locator(By.ID, 'search')
 
 
-class RegistriesDiscoverPage(BaseRegistriesPage):
+class BrandedRegistriesDiscoverPage(BaseRegistriesPage):
     url_addition = 'discover'
 
     identity = Locator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]'
     )
-    search_box = Locator(By.ID, 'search')
+    search_input = Locator(By.ID, 'search-input')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
-    osf_filter = Locator(
-        By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]'
-    )
-
-    # Group Locators
-    search_results = GroupLocator(By.CSS_SELECTOR, '._title_1wvii8')
-
-    def get_first_non_withdrawn_registration(self):
-        for result in self.search_results:
-            try:
-                result.find_element_by_class_name('label-default')
-            except NoSuchElementException:
-                return result.find_element_by_css_selector(
-                    '[data-test-result-title-id]'
-                )
 
 
 class BaseSubmittedRegistrationPage(GuidBasePage):

--- a/pages/search.py
+++ b/pages/search.py
@@ -8,8 +8,11 @@ from pages.base import OSFBasePage
 class SearchPage(OSFBasePage):
     url = settings.OSF_HOME + '/search/'
 
-    identity = Locator(By.ID, 'searchPageFullBar')
-    search_bar = Locator(By.ID, 'searchPageFullBar')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Search page main"]')
+    search_input = Locator(
+        By.CSS_SELECTOR, '.ember-text-field.ember-view._search-input_fvrbco'
+    )
+    search_button = Locator(By.CSS_SELECTOR, 'button[data-test-search-submit]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
     # Group Locators

--- a/tests/test_a11y_other_osf.py
+++ b/tests/test_a11y_other_osf.py
@@ -1,6 +1,8 @@
 import re
 
-from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
@@ -83,17 +85,18 @@ class TestRegisterPage:
         )
 
 
-@markers.legacy_page
+@markers.ember_page
 class TestSearchPage:
     def test_accessibility(self, driver, session, write_files, exclude_best_practice):
         search_page = SearchPage(driver)
         search_page.goto()
         assert SearchPage(driver, verify=True)
-        # Enter wildcard in search input box and press enter so that we have some search
-        #     results on the page before running accessibility test
-        search_page.search_bar.send_keys('*')
-        search_page.search_bar.send_keys(Keys.ENTER)
         search_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
         a11y.run_axe(
             driver,
             session,

--- a/tests/test_a11y_preprints.py
+++ b/tests/test_a11y_preprints.py
@@ -1,6 +1,5 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -190,10 +189,7 @@ class TestPreprintReviewsDashboardPage:
         dashboard_page = ReviewsDashboardPage(driver)
         dashboard_page.goto()
         assert ReviewsDashboardPage(driver, verify=True)
-        # Wait for list of preprints to load before calling axe
-        WebDriverWait(driver, 5).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, 'div._action-body_zlyyw2'))
-        )
+        dashboard_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,
@@ -209,14 +205,14 @@ class TestPreprintReviewsDashboardPage:
 class TestProviderReviewsPages:
     """To test the provider specific Reviews pages we must login as a user that has been
     setup as an administrator or moderator for one of the preprint providers that has
-    moderation enabled.  We are using MarXiv as the preprint provider since it exists
+    moderation enabled.  We are using selpremod as the preprint provider since it exists
     in all testing environments and has the moderation process enabled in each
     environment.
     """
 
     @pytest.fixture
     def provider(self, driver):
-        return osf_api.get_provider(type='preprints', provider_id='marxiv')
+        return osf_api.get_provider(type='preprints', provider_id='selpremod')
 
     def test_accessibility_reviews_submissions(
         self,
@@ -227,16 +223,17 @@ class TestProviderReviewsPages:
         exclude_best_practice,
         must_be_logged_in,
     ):
+        # There is a weird routing issue where you have to go to the Reviews Dashboard
+        # page first and then you can go to the Reviews Submissions page. If you try to
+        # go directly to the Reviews Submissions page first you get redirected back to
+        # the Reviews Dashboard page anyway.
+        dashboard_page = ReviewsDashboardPage(driver)
+        dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
         submissions_page = ReviewsSubmissionsPage(driver, provider=provider)
         submissions_page.goto()
         assert ReviewsSubmissionsPage(driver, verify=True)
-        # Wait for table to load before calling axe
-        if submissions_page.no_submissions.absent():
-            WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located(
-                    (By.CLASS_NAME, '_submission-info_xkm0pa')
-                )
-            )
+        submissions_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,
@@ -257,13 +254,7 @@ class TestProviderReviewsPages:
         withdrawals_page = ReviewsWithdrawalsPage(driver, provider=provider)
         withdrawals_page.goto()
         assert ReviewsWithdrawalsPage(driver, verify=True)
-        # Wait for table to load before calling axe
-        if withdrawals_page.no_requests.absent():
-            WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located(
-                    (By.CLASS_NAME, '_submission-info_17iwzt')
-                )
-            )
+        withdrawals_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,
@@ -284,10 +275,7 @@ class TestProviderReviewsPages:
         moderators_page = ReviewsModeratorsPage(driver, provider=provider)
         moderators_page.goto()
         assert ReviewsModeratorsPage(driver, verify=True)
-        # Wait for moderators list to load before calling axe
-        WebDriverWait(driver, 5).until(
-            EC.presence_of_element_located((By.CLASS_NAME, '_moderator-name_f83dob'))
-        )
+        moderators_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,
@@ -308,10 +296,7 @@ class TestProviderReviewsPages:
         notifications_page = ReviewsNotificationsPage(driver, provider=provider)
         notifications_page.goto()
         assert ReviewsNotificationsPage(driver, verify=True)
-        # Wait for notifications elements load before calling axe
-        WebDriverWait(driver, 5).until(
-            EC.presence_of_element_located((By.CLASS_NAME, 'notification-title'))
-        )
+        notifications_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,
@@ -332,6 +317,7 @@ class TestProviderReviewsPages:
         settings_page = ReviewsSettingsPage(driver, provider=provider)
         settings_page.goto()
         assert ReviewsSettingsPage(driver, verify=True)
+        settings_page.loading_indicator.here_then_gone()
         a11y.run_axe(
             driver,
             session,


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Updating accessibility tests as a result of the changes for the new OSF Search page.


## Summary of Changes

- api/osf_api.py - adding 2 new functions: get_most_recent_preprint_node_id() and get_most_recent_registration_node_id()
- pages/preprint.py - deleting class: PreprintDiscoverPage (this is early - the original phase 1 project plan intended to deprecate the OSF Preprints Discover page, but it was actually moved to a later project phase. But I am still removing this class now since it will go away some point soon)
- pages/registries.py - renaming RegistriesDiscoverPage to BrandedRegistriesDiscoverPage since the OSF Registries Discover page has been deprecated but the Branded versions of Discover pages still exist for now.
- pages/search.py - updating locators for the new Ember OSF Search page
- tests/test_a11y_other.osf.py - update test class: TestSearchPage for new Ember version of OSF Search page.
- tests/test_a11y_preprints.py - deleting of TestPreprintDiscoverPage class (this is early - the original phase 1 project plan intended to deprecate the OSF Preprints Discover page, but it was actually moved to a later project phase. But I am still removing this class now since it will go away some point soon) and updating TestPreprintDetailPage to use api to get an active Preprint instead of going through Discover page or Search page to find one.
- tests/test_a11y_registries.py - deleting TestRegistriesDiscoverPage class since the OSF Registries Discover page has been deprecated, and update to TestRegistrationDetailPage to use api to get active Registration instead of going through Discover page or Search page to find one.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFIx/search-improvements`

Run this test using
`tests/test_a11y_other.osf.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4614: SEL: A11y - Updates for Search Improvements Project
https://openscience.atlassian.net/browse/ENG-4614
