### PR TITLE
Add a11y check for Branded Preprint Discover pages

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -146,6 +146,13 @@ class PreprintSubmitPage(BasePreprintPage):
     )
 
 
+class PreprintDiscoverPage(BasePreprintPage):
+    url_addition = 'discover'
+
+    identity = Locator(By.ID, 'share-logo')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
 class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     url_base = urljoin(settings.OSF_HOME, '{guid}')
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add the accessibility check of Branded Preprint Discover pages where previously we were only checking the Branded  Preprint Landing pages.


## Summary of Changes

- pages/preprints.py - add PreprintDiscoverPage
- tests/test_a11y_preprints.py - add new test test_accessibility_discover


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/branded-preprints`

Run this test using
`tests/test_a11y_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
N/A